### PR TITLE
[codex] Add portable manifest path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add Windows-style path separator normalization for manifest diff and sandbox verification.
+- Expand README maintainer positioning.
+
 ## 0.1.0 - 2026-05-30
 
 - Initial release candidate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.1.1 - 2026-05-31
 
 - Add Windows-style path separator normalization for manifest diff and sandbox verification.
 - Expand README maintainer positioning.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ A small command-line toolkit for reproducible artifact verification in binary an
 
 It creates hash manifests, compares experiment outputs, and validates evidence bundles so results can be reviewed without relying on private source data.
 
+## Why this matters
+
+Generated artifacts are hard to review when the only proof is a large log, a private input tree, or a verbal claim that "nothing important changed." `repro-evidence-kit` keeps the review surface small: it records byte hashes, separates expected output changes from unexpected ones, and stores enough command context for another maintainer to rerun or challenge the evidence.
+
+The project is intentionally target-neutral. It should help maintainers in CI, security research, binary-analysis, data-processing, and automation workflows without requiring them to publish proprietary samples or project-specific case files.
+
 ## Use cases
 
 - Review what changed during artifact-heavy CI or release automation.

--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ This repository is for generic reproducibility tooling. Do not add proprietary b
 
 ## Status
 
-`0.1.0` is an initial release candidate. The CLI and schema are intentionally small and conservative.
+`0.1.x` is an early release series. The CLI and schema are intentionally small and conservative.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,8 @@ repro-evidence manifest create PATH -o manifest.json
 
 Each file entry includes relative path, byte size, and SHA-256.
 
+Manifest paths are serialized with `/` separators so manifests stay reviewable across platforms.
+
 ## `manifest diff`
 
 Compare two manifests.
@@ -19,6 +21,8 @@ repro-evidence manifest diff before.json after.json -o diff.json
 ```
 
 The report groups paths into `added`, `removed`, `changed`, and `unchanged`.
+
+When comparing manifests, Windows-style `\` separators are treated as the same logical path separators as `/`.
 
 ## `verify sandbox-run`
 
@@ -31,6 +35,8 @@ repro-evidence verify sandbox-run before.json after.json \
 ```
 
 Comma-separated allowlists are accepted for added, changed, and removed paths.
+
+Allowlist paths use the same normalization as manifest diffs, so `reports\summary.json` and `reports/summary.json` match the same logical artifact.
 
 ## `evidence validate`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repro-evidence-kit"
-version = "0.1.0"
+version = "0.1.1"
 description = "Reproducible artifact manifests, sandbox-output verification, and evidence-bundle validation."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/repro_evidence_kit/__init__.py
+++ b/src/repro_evidence_kit/__init__.py
@@ -1,3 +1,3 @@
 """Reproducible artifact evidence toolkit."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -17,7 +17,7 @@ def _csv_set(value: str | None) -> set[str]:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="repro-evidence", description="Reproducible artifact manifest and evidence-bundle tools.")
-    parser.add_argument("--version", action="version", version="repro-evidence 0.1.0")
+    parser.add_argument("--version", action="version", version="repro-evidence 0.1.1")
     sub = parser.add_subparsers(dest="command", required=True)
 
     manifest = sub.add_parser("manifest", help="Create or compare file manifests")

--- a/src/repro_evidence_kit/manifest.py
+++ b/src/repro_evidence_kit/manifest.py
@@ -11,6 +11,11 @@ from typing import Any, Iterable
 MANIFEST_VERSION = "1.0"
 
 
+def normalize_manifest_path(path: object) -> str:
+    """Return the manifest's portable logical path form."""
+    return str(path).replace("\\", "/")
+
+
 def sha256_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
     h = hashlib.sha256()
     with path.open("rb") as f:
@@ -33,7 +38,7 @@ def create_manifest(root: Path, *, include_mtime: bool = False) -> dict[str, Any
     root = root.resolve()
     entries: list[dict[str, Any]] = []
     for file_path in iter_files(root):
-        rel = file_path.resolve().relative_to(root if root.is_dir() else root.parent).as_posix()
+        rel = normalize_manifest_path(file_path.resolve().relative_to(root if root.is_dir() else root.parent).as_posix())
         st = file_path.stat()
         item: dict[str, Any] = {
             "path": rel,
@@ -93,8 +98,8 @@ class ManifestDiff:
 
 
 def diff_manifests(before: dict[str, Any], after: dict[str, Any]) -> ManifestDiff:
-    before_files = {item["path"]: item for item in before.get("files", [])}
-    after_files = {item["path"]: item for item in after.get("files", [])}
+    before_files = {normalize_manifest_path(item["path"]): item for item in before.get("files", [])}
+    after_files = {normalize_manifest_path(item["path"]): item for item in after.get("files", [])}
     before_paths = set(before_files)
     after_paths = set(after_files)
     added = sorted(after_paths - before_paths)

--- a/src/repro_evidence_kit/verify.py
+++ b/src/repro_evidence_kit/verify.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from .manifest import diff_manifests
+from .manifest import diff_manifests, normalize_manifest_path
 
 
 def verify_sandbox_output(before: dict[str, Any], after: dict[str, Any], *, allow_added: set[str] | None = None, allow_changed: set[str] | None = None, allow_removed: set[str] | None = None) -> dict[str, Any]:
-    allow_added = allow_added or set()
-    allow_changed = allow_changed or set()
-    allow_removed = allow_removed or set()
+    allow_added = {normalize_manifest_path(path) for path in (allow_added or set())}
+    allow_changed = {normalize_manifest_path(path) for path in (allow_changed or set())}
+    allow_removed = {normalize_manifest_path(path) for path in (allow_removed or set())}
     diff = diff_manifests(before, after).as_dict()
     unexpected_added = sorted(set(diff["added"]) - allow_added)
     unexpected_changed = sorted(set(diff["changed"]) - allow_changed)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -17,12 +17,29 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(manifest["files"][0]["path"], "a.txt")
         self.assertEqual(len(manifest["files"][0]["sha256"]), 64)
 
+    def test_create_manifest_uses_posix_paths_for_nested_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            nested = root / "logs"
+            nested.mkdir()
+            (nested / "run.txt").write_text("ok", encoding="utf-8")
+            manifest = create_manifest(root)
+        self.assertEqual(manifest["files"][0]["path"], "logs/run.txt")
+
     def test_diff_manifests(self):
         before = {"files": [{"path": "a.txt", "size": 1, "sha256": "0" * 64}]}
         after = {"files": [{"path": "a.txt", "size": 2, "sha256": "1" * 64}, {"path": "b.txt", "size": 1, "sha256": "2" * 64}]}
         diff = diff_manifests(before, after).as_dict()
         self.assertEqual(diff["changed"], ["a.txt"])
         self.assertEqual(diff["added"], ["b.txt"])
+
+    def test_diff_normalizes_windows_style_manifest_paths(self):
+        before = {"files": [{"path": "logs\\run.txt", "size": 2, "sha256": "0" * 64}]}
+        after = {"files": [{"path": "logs/run.txt", "size": 2, "sha256": "0" * 64}]}
+        diff = diff_manifests(before, after).as_dict()
+        self.assertEqual(diff["unchanged"], ["logs/run.txt"])
+        self.assertEqual(diff["added"], [])
+        self.assertEqual(diff["removed"], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -19,6 +19,13 @@ class VerifyTests(unittest.TestCase):
         result = verify_sandbox_output(before, after, allow_added={"report.json"})
         self.assertTrue(result["ok"])
 
+    def test_allowlist_normalizes_windows_style_paths(self):
+        before = {"files": []}
+        after = {"files": [{"path": "reports\\summary.json", "size": 2, "sha256": "a" * 64}]}
+        result = verify_sandbox_output(before, after, allow_added={"reports/summary.json"})
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["allowed"]["added"], ["reports/summary.json"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- normalize manifest paths so Windows-style `\` separators compare as the same logical artifact paths as `/`
- normalize sandbox allowlists through the same path boundary
- expand README maintainer positioning and document cross-platform path behavior

## Why

Maintainers may compare manifests generated or edited on different platforms. Treating separator-only differences as artifact changes creates noisy diffs and false sandbox verification failures.

## Validation

- `PYTHONPATH=src python3 -m unittest discover -s tests`
- `PYTHONPATH=src python3 -m repro_evidence_kit evidence validate examples/evidence-bundle.yaml`
- `PYTHONPATH=src python3 -m repro_evidence_kit manifest create examples/dummy-binary -o /tmp/repro-manifest.json`
- CI leakage audit grep command
- CLI sandbox verification with `reports\\summary.json` manifest path allowed by `reports/summary.json`

## Notes

Local `python` was not on PATH, so local checks used `python3`. A local venv install attempt was blocked because `python3.12-venv`/ensurepip is unavailable on this host; source-tree checks were run with `PYTHONPATH=src` instead.
