### PR TITLE
[codex] Document CLI exit codes and CI cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Document stable CLI exit-code meanings and add regression coverage.
+- Add a small GitHub Actions cookbook for maintainer CI usage.
+- Clarify source-based installation until a package index release exists.
+
 ## 0.1.1 - 2026-05-31
 
 - Add Windows-style path separator normalization for manifest diff and sandbox verification.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ The project is intentionally target-neutral. It should help maintainers in CI, s
 
 ## Install
 
+Until a package index release is published, install from the repository:
+
 ```bash
-pip install repro-evidence-kit
+pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.1.1"
 ```
 
 For local development:
@@ -66,6 +68,7 @@ The command exits `0` when all changes are allowed and `1` when unexpected chang
 - [Tutorial](docs/tutorial.md)
 - [Evidence bundle format](docs/evidence-bundle-format.md)
 - [Maintainer workflow](docs/maintainer-workflow.md)
+- [GitHub Actions cookbook](docs/github-actions.md)
 - [Design principles](docs/design-principles.md)
 - [Roadmap](ROADMAP.md)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,5 +1,17 @@
 # CLI reference
 
+## Exit codes
+
+All commands use the same top-level exit-code contract:
+
+| Code | Meaning | Examples |
+| --- | --- | --- |
+| `0` | The command completed and the checked predicate passed. | Manifest written, manifests diffed, evidence bundle valid, sandbox output contains only allowed changes. |
+| `1` | The command completed and found an expected validation or verification failure. | Evidence bundle is structurally invalid, sandbox output contains unexpected added/changed/removed paths. |
+| `2` | The command could not complete because of an input, parsing, filesystem, or runtime error. | Missing JSON file, malformed manifest JSON, unreadable evidence file. |
+
+Use `1` as a CI policy failure and `2` as an infrastructure or invocation failure.
+
 ## `manifest create`
 
 Create a JSON manifest for a file or directory.
@@ -45,3 +57,5 @@ Validate a YAML or JSON evidence bundle.
 ```bash
 repro-evidence evidence validate examples/evidence-bundle.yaml
 ```
+
+Exit code `1` means the file was read successfully but the bundle failed validation. Exit code `2` means the file could not be read or parsed.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,75 @@
+# GitHub Actions cookbook
+
+These snippets use synthetic paths and generic artifact names. Replace the paths with outputs from your own repository, but do not commit private source data or proprietary samples.
+
+## Validate evidence bundles
+
+```yaml
+name: Evidence
+
+on:
+  pull_request:
+
+jobs:
+  evidence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install -e .
+      - run: python -m repro_evidence_kit evidence validate examples/evidence-bundle.yaml
+```
+
+`evidence validate` exits `0` when the bundle is valid, `1` when the bundle is readable but invalid, and `2` when the command cannot read or parse the input.
+
+## Create and upload a manifest
+
+```yaml
+name: Artifact manifest
+
+on:
+  pull_request:
+
+jobs:
+  manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install -e .
+      - run: python -m repro_evidence_kit manifest create examples/dummy-binary -o manifest.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: manifest
+          path: manifest.json
+```
+
+## Gate sandbox output changes
+
+```yaml
+name: Sandbox verification
+
+on:
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install -e .
+      - run: mkdir -p sandbox && printf 'input\n' > sandbox/input.txt
+      - run: python -m repro_evidence_kit manifest create sandbox -o before.json
+      - run: printf '{"ok": true}\n' > sandbox/report.json
+      - run: python -m repro_evidence_kit manifest create sandbox -o after.json
+      - run: python -m repro_evidence_kit verify sandbox-run before.json after.json --allow-added report.json
+```
+
+Unexpected added, changed, or removed paths produce exit code `1`, which fails the job as a policy failure.

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -25,6 +25,8 @@ python -m repro_evidence_kit manifest create examples/dummy-binary -o /tmp/manif
 
 This repository's CI also runs a leakage audit that rejects project-specific or proprietary-sample markers.
 
+For copyable GitHub Actions snippets, see the [GitHub Actions cookbook](github-actions.md).
+
 ## Codex-assisted maintenance
 
 Useful Codex tasks for this project include:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import tempfile
 import unittest
@@ -18,6 +20,43 @@ class CliTests(unittest.TestCase):
             self.assertEqual(code, 0)
             data = json.loads(output.read_text(encoding="utf-8"))
             self.assertEqual(data["file_count"], 1)
+
+    def test_evidence_validate_invalid_bundle_returns_1(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "bad.yaml"
+            output = root / "result.json"
+            bundle.write_text("title: Missing required fields\n", encoding="utf-8")
+            code = main(["evidence", "validate", str(bundle), "-o", str(output)])
+            self.assertEqual(code, 1)
+            data = json.loads(output.read_text(encoding="utf-8"))
+            self.assertFalse(data["ok"])
+            self.assertIn("missing top-level field: inputs", data["errors"])
+
+    def test_verify_sandbox_unexpected_output_returns_1(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            before = root / "before.json"
+            after = root / "after.json"
+            output = root / "verify.json"
+            before.write_text(json.dumps({"files": []}), encoding="utf-8")
+            after.write_text(
+                json.dumps({"files": [{"path": "report.json", "size": 2, "sha256": "a" * 64}]}),
+                encoding="utf-8",
+            )
+            code = main(["verify", "sandbox-run", str(before), str(after), "-o", str(output)])
+            self.assertEqual(code, 1)
+            data = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(data["unexpected"]["added"], ["report.json"])
+
+    def test_missing_input_file_returns_2(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                code = main(["manifest", "diff", str(root / "missing-before.json"), str(root / "missing-after.json")])
+            self.assertEqual(code, 2)
+            self.assertIn("error:", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- document the stable CLI exit-code contract (`0` success, `1` validation/policy failure, `2` invocation/runtime/input error)
- add CLI regression tests for invalid evidence bundles, unexpected sandbox output, and missing input files
- add a small GitHub Actions cookbook covering evidence validation, manifest upload, and sandbox-output gating
- clarify source-based install instructions until a package-index release exists

Closes #2.
Closes #3.

## Validation

- `PYTHONPATH=src python3 -m unittest discover -s tests`
- explicit CLI exit-code proof: valid evidence `0`, invalid evidence `1`, missing manifest input `2`
- sandbox cookbook command sequence proof with `--allow-added report.json`
- CI leakage audit grep command
- `git diff --check`

## Notes

This intentionally does not add JSON Schema validation, Markdown reports, path filters, or PyPI publication.
