### PR TITLE
[codex] Add Markdown manifest diff reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add Markdown output for `manifest diff` reports.
 - Document stable CLI exit-code meanings and add regression coverage.
 - Add a small GitHub Actions cookbook for maintainer CI usage.
 - Clarify source-based installation until a package index release exists.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,6 +36,12 @@ The report groups paths into `added`, `removed`, `changed`, and `unchanged`.
 
 When comparing manifests, Windows-style `\` separators are treated as the same logical path separators as `/`.
 
+Use `--format markdown` when you want a review-friendly Markdown report instead of JSON:
+
+```bash
+repro-evidence manifest diff before.json after.json --format markdown -o diff.md
+```
+
 ## `verify sandbox-run`
 
 Verify that only explicitly allowed paths changed.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -27,6 +27,12 @@ repro-evidence manifest diff before.json after.json
 
 The diff separates added, removed, changed, and unchanged paths.
 
+For a report that can be pasted into an issue or pull request, write Markdown:
+
+```bash
+repro-evidence manifest diff before.json after.json --format markdown -o diff.md
+```
+
 ## 4. Verify allowed changes
 
 If `report.txt` is the only expected new artifact:

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 from .evidence import load_evidence, validate_evidence_bundle
-from .manifest import create_manifest, diff_manifests, load_json, write_json
+from .manifest import create_manifest, diff_manifests, load_json, write_json, write_text
 from .verify import verify_sandbox_output
 
 
@@ -30,6 +30,7 @@ def build_parser() -> argparse.ArgumentParser:
     diff = manifest_sub.add_parser("diff", help="Compare two JSON manifests")
     diff.add_argument("before", type=Path)
     diff.add_argument("after", type=Path)
+    diff.add_argument("--format", choices=("json", "markdown"), default="json")
     diff.add_argument("-o", "--output", type=Path)
 
     verify = sub.add_parser("verify", help="Verify experiment/sandbox outputs")
@@ -57,8 +58,11 @@ def main(argv: list[str] | None = None) -> int:
             write_json(create_manifest(args.path, include_mtime=args.include_mtime), args.output)
             return 0
         if args.command == "manifest" and args.manifest_command == "diff":
-            result = diff_manifests(load_json(args.before), load_json(args.after)).as_dict()
-            write_json(result, args.output)
+            result = diff_manifests(load_json(args.before), load_json(args.after))
+            if args.format == "markdown":
+                write_text(result.as_markdown(), args.output)
+            else:
+                write_json(result.as_dict(), args.output)
             return 0
         if args.command == "verify" and args.verify_command == "sandbox-run":
             result = verify_sandbox_output(

--- a/src/repro_evidence_kit/manifest.py
+++ b/src/repro_evidence_kit/manifest.py
@@ -75,6 +75,14 @@ def write_json(data: Any, path: Path | None) -> None:
         path.write_text(text, encoding="utf-8")
 
 
+def write_text(text: str, path: Path | None) -> None:
+    if path is None:
+        print(text, end="")
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+
 @dataclass(frozen=True)
 class ManifestDiff:
     added: list[str]
@@ -95,6 +103,34 @@ class ManifestDiff:
             "changed": self.changed,
             "unchanged": self.unchanged,
         }
+
+    def as_markdown(self) -> str:
+        lines = [
+            "# Manifest diff",
+            "",
+            "## Summary",
+            "",
+            "| Status | Count |",
+            "| --- | ---: |",
+            f"| Added | {len(self.added)} |",
+            f"| Removed | {len(self.removed)} |",
+            f"| Changed | {len(self.changed)} |",
+            f"| Unchanged | {len(self.unchanged)} |",
+            "",
+        ]
+        for title, paths in (
+            ("Added", self.added),
+            ("Removed", self.removed),
+            ("Changed", self.changed),
+            ("Unchanged", self.unchanged),
+        ):
+            lines.extend([f"## {title}", ""])
+            if paths:
+                lines.extend(f"- `{path}`" for path in paths)
+            else:
+                lines.append("_None._")
+            lines.append("")
+        return "\n".join(lines) + "\n"
 
 
 def diff_manifests(before: dict[str, Any], after: dict[str, Any]) -> ManifestDiff:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,24 @@ class CliTests(unittest.TestCase):
             self.assertEqual(code, 2)
             self.assertIn("error:", stderr.getvalue())
 
+    def test_manifest_diff_markdown_cli(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            before = root / "before.json"
+            after = root / "after.json"
+            output = root / "diff.md"
+            before.write_text(json.dumps({"files": []}), encoding="utf-8")
+            after.write_text(
+                json.dumps({"files": [{"path": "report.md", "size": 2, "sha256": "a" * 64}]}),
+                encoding="utf-8",
+            )
+            code = main(["manifest", "diff", str(before), str(after), "--format", "markdown", "-o", str(output)])
+            self.assertEqual(code, 0)
+            text = output.read_text(encoding="utf-8")
+            self.assertIn("# Manifest diff", text)
+            self.assertIn("| Added | 1 |", text)
+            self.assertIn("- `report.md`", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -41,6 +41,21 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(diff["added"], [])
         self.assertEqual(diff["removed"], [])
 
+    def test_diff_formats_markdown_report(self):
+        before = {"files": [{"path": "old.txt", "size": 1, "sha256": "0" * 64}]}
+        after = {
+            "files": [
+                {"path": "old.txt", "size": 2, "sha256": "1" * 64},
+                {"path": "new.txt", "size": 1, "sha256": "2" * 64},
+            ]
+        }
+        markdown = diff_manifests(before, after).as_markdown()
+        self.assertIn("# Manifest diff", markdown)
+        self.assertIn("| Added | 1 |", markdown)
+        self.assertIn("| Changed | 1 |", markdown)
+        self.assertIn("- `new.txt`", markdown)
+        self.assertIn("- `old.txt`", markdown)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds an opt-in Markdown output mode for `manifest diff` via `--format markdown`.
- Keeps JSON as the default machine-readable output.
- Documents the Markdown report workflow in CLI and tutorial docs.
- Adds synthetic-manifest tests for the Markdown report shape.

Closes #4.

## Validation

- `uv run pytest -q` — 15 passed
- Manual CLI smoke: `uv run repro-evidence manifest diff before.json after.json --format markdown -o diff.md`
