### PR TITLE
[codex] Add manifest include exclude filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add include/exclude filters for manifest creation.
 - Add Markdown output for `manifest diff` reports.
 - Document stable CLI exit-code meanings and add regression coverage.
 - Add a small GitHub Actions cookbook for maintainer CI usage.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The project is intentionally target-neutral. It should help maintainers in CI, s
 
 ## Features
 
-- Create deterministic SHA-256 manifests for files or directories.
+- Create deterministic SHA-256 manifests for files or filtered directory trees.
 - Diff two manifests to identify added, removed, changed, and unchanged artifacts.
 - Verify sandbox/experiment outputs against explicit allowlists.
 - Validate simple YAML or JSON evidence bundles.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,18 @@ Each file entry includes relative path, byte size, and SHA-256.
 
 Manifest paths are serialized with `/` separators so manifests stay reviewable across platforms.
 
+Use `--include` and `--exclude` to filter large artifact trees by manifest-relative path:
+
+```bash
+repro-evidence manifest create artifacts \
+  --include reports \
+  --include "*.json" \
+  --exclude "*.tmp" \
+  -o manifest.json
+```
+
+Filters are deterministic and use POSIX-style manifest-relative globs or subtree paths. Includes run first; when at least one include is supplied, only matching files remain. Excludes run after includes and remove matching files. Repeated flags and comma-separated values are accepted. When filters are used, the manifest records normalized include/exclude patterns in a `filters` metadata object.
+
 ## `manifest diff`
 
 Compare two manifests.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,6 +10,17 @@ repro-evidence manifest create examples/sandbox-run -o before.json
 
 The manifest records relative paths, file sizes, and SHA-256 hashes.
 
+For a larger tree, narrow the manifest with include/exclude filters:
+
+```bash
+repro-evidence manifest create examples/sandbox-run \
+  --include "*.txt" \
+  --exclude "*.tmp" \
+  -o before.json
+```
+
+Includes are applied first, excludes second, and the active filter patterns are written into manifest metadata for reproducibility.
+
 ## 2. Run an experiment
 
 For a real workflow, this would be a build, parser, analysis script, or sandboxed automation step. For a minimal local example:

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -15,6 +15,12 @@ def _csv_set(value: str | None) -> set[str]:
     return {part.strip() for part in value.split(",") if part.strip()}
 
 
+def _csv_list(values: list[str] | None) -> list[str]:
+    if not values:
+        return []
+    return [part.strip() for value in values for part in value.split(",") if part.strip()]
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="repro-evidence", description="Reproducible artifact manifest and evidence-bundle tools.")
     parser.add_argument("--version", action="version", version="repro-evidence 0.1.1")
@@ -26,6 +32,8 @@ def build_parser() -> argparse.ArgumentParser:
     create.add_argument("path", type=Path)
     create.add_argument("-o", "--output", type=Path)
     create.add_argument("--include-mtime", action="store_true")
+    create.add_argument("--include", action="append", help="Manifest-relative glob or subtree path to include; may be repeated or comma-separated")
+    create.add_argument("--exclude", action="append", help="Manifest-relative glob or subtree path to exclude after includes; may be repeated or comma-separated")
 
     diff = manifest_sub.add_parser("diff", help="Compare two JSON manifests")
     diff.add_argument("before", type=Path)
@@ -55,7 +63,15 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         if args.command == "manifest" and args.manifest_command == "create":
-            write_json(create_manifest(args.path, include_mtime=args.include_mtime), args.output)
+            write_json(
+                create_manifest(
+                    args.path,
+                    include_mtime=args.include_mtime,
+                    include=_csv_list(args.include),
+                    exclude=_csv_list(args.exclude),
+                ),
+                args.output,
+            )
             return 0
         if args.command == "manifest" and args.manifest_command == "diff":
             result = diff_manifests(load_json(args.before), load_json(args.after))

--- a/src/repro_evidence_kit/manifest.py
+++ b/src/repro_evidence_kit/manifest.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import fnmatch
 import hashlib
 import json
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Sequence
 
 MANIFEST_VERSION = "1.0"
 
@@ -34,11 +35,40 @@ def iter_files(root: Path) -> Iterable[Path]:
             yield Path(dirpath) / name
 
 
-def create_manifest(root: Path, *, include_mtime: bool = False) -> dict[str, Any]:
+def normalize_filter_patterns(patterns: Sequence[str] | None) -> list[str]:
+    if not patterns:
+        return []
+    return sorted({normalize_manifest_path(pattern.strip()) for pattern in patterns if pattern.strip()})
+
+
+def path_matches_filter(path: str, pattern: str) -> bool:
+    pattern = normalize_manifest_path(pattern)
+    return path == pattern or path.startswith(f"{pattern.rstrip('/')}/") or fnmatch.fnmatchcase(path, pattern)
+
+
+def path_selected(path: str, *, include: Sequence[str], exclude: Sequence[str]) -> bool:
+    if include and not any(path_matches_filter(path, pattern) for pattern in include):
+        return False
+    if exclude and any(path_matches_filter(path, pattern) for pattern in exclude):
+        return False
+    return True
+
+
+def create_manifest(
+    root: Path,
+    *,
+    include_mtime: bool = False,
+    include: Sequence[str] | None = None,
+    exclude: Sequence[str] | None = None,
+) -> dict[str, Any]:
     root = root.resolve()
+    include_patterns = normalize_filter_patterns(include)
+    exclude_patterns = normalize_filter_patterns(exclude)
     entries: list[dict[str, Any]] = []
     for file_path in iter_files(root):
         rel = normalize_manifest_path(file_path.resolve().relative_to(root if root.is_dir() else root.parent).as_posix())
+        if not path_selected(rel, include=include_patterns, exclude=exclude_patterns):
+            continue
         st = file_path.stat()
         item: dict[str, Any] = {
             "path": rel,
@@ -48,7 +78,7 @@ def create_manifest(root: Path, *, include_mtime: bool = False) -> dict[str, Any
         if include_mtime:
             item["mtime_ns"] = st.st_mtime_ns
         entries.append(item)
-    return {
+    manifest: dict[str, Any] = {
         "manifest_version": MANIFEST_VERSION,
         "created_at": datetime.now(timezone.utc).isoformat(),
         "root_name": root.name,
@@ -56,6 +86,14 @@ def create_manifest(root: Path, *, include_mtime: bool = False) -> dict[str, Any
         "total_bytes": sum(e["size"] for e in entries),
         "files": entries,
     }
+    if include_patterns or exclude_patterns:
+        manifest["filters"] = {
+            "include": include_patterns,
+            "exclude": exclude_patterns,
+            "order": "include_then_exclude",
+            "pattern_syntax": "POSIX-style manifest-relative glob or subtree path",
+        }
+    return manifest
 
 
 def load_json(path: Path) -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,6 +76,31 @@ class CliTests(unittest.TestCase):
             self.assertIn("| Added | 1 |", text)
             self.assertIn("- `report.md`", text)
 
+    def test_manifest_create_cli_include_exclude_filters(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "reports").mkdir()
+            (root / "reports" / "keep.txt").write_text("keep", encoding="utf-8")
+            (root / "reports" / "skip.log").write_text("skip", encoding="utf-8")
+            (root / "cache.txt").write_text("cache", encoding="utf-8")
+            output = root / "manifest.json"
+            code = main([
+                "manifest",
+                "create",
+                str(root),
+                "--include",
+                "reports",
+                "--exclude",
+                "*.log",
+                "-o",
+                str(output),
+            ])
+            self.assertEqual(code, 0)
+            data = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual([item["path"] for item in data["files"]], ["reports/keep.txt"])
+            self.assertEqual(data["filters"]["include"], ["reports"])
+            self.assertEqual(data["filters"]["exclude"], ["*.log"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -56,6 +56,30 @@ class ManifestTests(unittest.TestCase):
         self.assertIn("- `new.txt`", markdown)
         self.assertIn("- `old.txt`", markdown)
 
+    def test_create_manifest_filters_include_exclude_and_metadata(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "keep").mkdir()
+            (root / "keep" / "result.txt").write_text("result", encoding="utf-8")
+            (root / "keep" / "debug.tmp").write_text("debug", encoding="utf-8")
+            (root / "cache").mkdir()
+            (root / "cache" / "noise.txt").write_text("noise", encoding="utf-8")
+            manifest = create_manifest(root, include=["keep"], exclude=["*.tmp"])
+        self.assertEqual([item["path"] for item in manifest["files"]], ["keep/result.txt"])
+        self.assertEqual(manifest["file_count"], 1)
+        self.assertEqual(manifest["filters"]["include"], ["keep"])
+        self.assertEqual(manifest["filters"]["exclude"], ["*.tmp"])
+        self.assertEqual(manifest["filters"]["order"], "include_then_exclude")
+
+    def test_create_manifest_default_unfiltered_behavior_is_unchanged(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "keep.txt").write_text("keep", encoding="utf-8")
+            (root / "noise.tmp").write_text("noise", encoding="utf-8")
+            manifest = create_manifest(root)
+        self.assertEqual([item["path"] for item in manifest["files"]], ["keep.txt", "noise.tmp"])
+        self.assertNotIn("filters", manifest)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Add explicit include/exclude filters to `repro-evidence manifest create` for large artifact trees.

## What changed

- Adds `--include` and `--exclude` options for manifest creation.
- Applies includes first, then excludes.
- Supports repeated flags and comma-separated values.
- Uses manifest-relative POSIX-style glob patterns or subtree paths.
- Records active filters in manifest metadata for reproducibility.
- Documents filter ordering and behavior.
- Adds regression coverage for included, excluded, and default unfiltered behavior.

## Validation

- `uv run pytest -q` -> 18 passed
- Manual CLI smoke: filtered manifest contained only `reports/result.json` and recorded `filters` metadata.

Closes #5.
