### PR TITLE
[codex] Add optional evidence schema validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: python -m pip install -e .
+      - run: python -m pip install -e ".[schema]"
       - run: python -m unittest discover -s tests
       - run: python -m repro_evidence_kit evidence validate examples/evidence-bundle.yaml
       - run: python -m repro_evidence_kit manifest create examples/dummy-binary -o /tmp/repro-manifest.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add optional JSON Schema validation for evidence bundles.
 - Add include/exclude filters for manifest creation.
 - Add Markdown output for `manifest diff` reports.
 - Document stable CLI exit-code meanings and add regression coverage.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The project is intentionally target-neutral. It should help maintainers in CI, s
 - Create deterministic SHA-256 manifests for files or filtered directory trees.
 - Diff two manifests to identify added, removed, changed, and unchanged artifacts.
 - Verify sandbox/experiment outputs against explicit allowlists.
-- Validate simple YAML or JSON evidence bundles.
+- Validate simple YAML or JSON evidence bundles, with optional JSON Schema checks.
 - Includes only synthetic public examples.
 
 ## Install

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,4 +76,15 @@ Validate a YAML or JSON evidence bundle.
 repro-evidence evidence validate examples/evidence-bundle.yaml
 ```
 
-Exit code `1` means the file was read successfully but the bundle failed validation. Exit code `2` means the file could not be read or parsed.
+The default validator is lightweight and has no dependency beyond the base package. It checks required top-level fields, artifact `path`/`sha256` presence, and command shape. Use it for fast local checks and low-friction CI.
+
+For stricter JSON Schema validation, install the optional schema extra and pass `--schema`:
+
+```bash
+pip install "repro-evidence-kit[schema]"
+repro-evidence evidence validate examples/evidence-bundle.yaml --schema
+```
+
+Schema-backed validation uses `schemas/evidence-bundle.schema.json` and additionally enforces constraints such as SHA-256 hex format and numeric size bounds. Use `--schema-path custom.schema.json` with `--schema` to test a local schema variant.
+
+Exit code `1` means the file was read successfully but the bundle failed validation. Exit code `2` means the file could not be read, parsed, or schema validation was requested without the optional dependency.

--- a/docs/evidence-bundle-format.md
+++ b/docs/evidence-bundle-format.md
@@ -21,3 +21,11 @@ Commands require either:
 - `command`
 
 The format is intentionally small. It is not a provenance database and does not store private source material.
+
+## Validation modes
+
+`repro-evidence evidence validate BUNDLE` uses the lightweight validator. It is intended for base installs and checks the stable required fields without requiring optional packages.
+
+`repro-evidence evidence validate BUNDLE --schema` uses `schemas/evidence-bundle.schema.json` through the optional `jsonschema` dependency. Use schema-backed validation in CI when maintainers want stricter contract checks such as SHA-256 hex formatting and numeric bounds.
+
+The schema path can be overridden for local experiments with `--schema-path`, but repository CI should use the checked-in schema by default.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ classifiers = [
 dependencies = ["PyYAML>=6.0"]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0"]
+dev = ["pytest>=8.0", "jsonschema>=4.0"]
+schema = ["jsonschema>=4.0"]
 
 [project.scripts]
 repro-evidence = "repro_evidence_kit.cli:main"

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from .evidence import load_evidence, validate_evidence_bundle
+from .evidence import load_evidence, validate_evidence_bundle, validate_evidence_bundle_schema
 from .manifest import create_manifest, diff_manifests, load_json, write_json, write_text
 from .verify import verify_sandbox_output
 
@@ -55,6 +55,8 @@ def build_parser() -> argparse.ArgumentParser:
     evidence_sub = evidence.add_subparsers(dest="evidence_command", required=True)
     val = evidence_sub.add_parser("validate", help="Validate an evidence bundle YAML/JSON file")
     val.add_argument("bundle", type=Path)
+    val.add_argument("--schema", action="store_true", help="Validate with schemas/evidence-bundle.schema.json using the optional jsonschema dependency")
+    val.add_argument("--schema-path", type=Path, help="Use a custom JSON Schema path with --schema")
     val.add_argument("-o", "--output", type=Path)
     return parser
 
@@ -91,7 +93,8 @@ def main(argv: list[str] | None = None) -> int:
             write_json(result, args.output)
             return 0 if result["ok"] else 1
         if args.command == "evidence" and args.evidence_command == "validate":
-            result = validate_evidence_bundle(load_evidence(args.bundle))
+            bundle = load_evidence(args.bundle)
+            result = validate_evidence_bundle_schema(bundle, args.schema_path) if args.schema else validate_evidence_bundle(bundle)
             write_json(result, args.output)
             return 0 if result["ok"] else 1
     except Exception as exc:

--- a/src/repro_evidence_kit/evidence.py
+++ b/src/repro_evidence_kit/evidence.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from importlib import resources
 from pathlib import Path
 from typing import Any
 
@@ -8,6 +9,13 @@ try:
     import yaml
 except Exception:  # pragma: no cover
     yaml = None
+
+try:
+    from jsonschema import Draft202012Validator
+except Exception:  # pragma: no cover
+    Draft202012Validator = None
+
+REPO_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "evidence-bundle.schema.json"
 
 REQUIRED_TOP_LEVEL = {"schema_version", "title", "inputs", "commands", "outputs"}
 REQUIRED_ARTIFACT_FIELDS = {"path", "sha256"}
@@ -56,3 +64,39 @@ def validate_evidence_bundle(data: dict[str, Any]) -> dict[str, Any]:
                 elif "argv" not in item and "command" not in item:
                     errors.append(f"commands[{i}] missing field: argv or command")
     return {"ok": not errors, "errors": errors}
+
+
+def validate_evidence_bundle_schema(data: dict[str, Any], schema_path: Path | None = None) -> dict[str, Any]:
+    if Draft202012Validator is None:
+        raise ValueError("schema validation requires the optional 'jsonschema' dependency; install repro-evidence-kit[schema]")
+    schema_file = schema_path or default_schema_path()
+    schema = load_json_schema(schema_file)
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda error: list(error.path))
+    return {
+        "ok": not errors,
+        "errors": [format_schema_error(error) for error in errors],
+        "validator": "jsonschema Draft 2020-12",
+        "schema_path": str(schema_file),
+    }
+
+
+def default_schema_path() -> Path:
+    if REPO_SCHEMA_PATH.exists():
+        return REPO_SCHEMA_PATH
+    return Path(str(resources.files("repro_evidence_kit.schemas") / "evidence-bundle.schema.json"))
+
+
+def load_json_schema(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+    if not isinstance(schema, dict):
+        raise ValueError(f"schema must be a JSON object: {path}")
+    return schema
+
+
+def format_schema_error(error: Any) -> str:
+    location = "/".join(str(part) for part in error.path)
+    if not location:
+        location = "<root>"
+    return f"{location}: {error.message}"

--- a/src/repro_evidence_kit/schemas/evidence-bundle.schema.json
+++ b/src/repro_evidence_kit/schemas/evidence-bundle.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/repro-evidence-kit/evidence-bundle.schema.json",
+  "title": "Evidence Bundle",
+  "type": "object",
+  "required": ["schema_version", "title", "inputs", "commands", "outputs"],
+  "properties": {
+    "schema_version": {"type": "string"},
+    "title": {"type": "string"},
+    "description": {"type": "string"},
+    "inputs": {"type": "array", "items": {"$ref": "#/$defs/artifact"}},
+    "commands": {"type": "array", "items": {"$ref": "#/$defs/command"}},
+    "outputs": {"type": "array", "items": {"$ref": "#/$defs/artifact"}},
+    "notes": {"type": "array", "items": {"type": "string"}}
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {"type": "string"},
+        "sha256": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"},
+        "size": {"type": "integer", "minimum": 0},
+        "role": {"type": "string"}
+      }
+    },
+    "command": {
+      "type": "object",
+      "properties": {
+        "argv": {"type": "array", "items": {"type": "string"}},
+        "command": {"type": "string"},
+        "cwd": {"type": "string"},
+        "exit_code": {"type": "integer"}
+      },
+      "anyOf": [{"required": ["argv"]}, {"required": ["command"]}]
+    }
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib import Path
 
 from repro_evidence_kit.cli import main
+from repro_evidence_kit.evidence import Draft202012Validator
 
 
 class CliTests(unittest.TestCase):
@@ -100,6 +101,25 @@ class CliTests(unittest.TestCase):
             self.assertEqual([item["path"] for item in data["files"]], ["reports/keep.txt"])
             self.assertEqual(data["filters"]["include"], ["reports"])
             self.assertEqual(data["filters"]["exclude"], ["*.log"])
+
+    @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
+    def test_evidence_validate_schema_cli_returns_1_for_schema_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "bundle.json"
+            output = root / "result.json"
+            bundle.write_text(json.dumps({
+                "schema_version": "1.0",
+                "title": "Example",
+                "inputs": [{"path": "input.bin", "sha256": "not-a-hex-digest"}],
+                "commands": [{"argv": ["tool", "input.bin"]}],
+                "outputs": [{"path": "output.bin", "sha256": "b" * 64}],
+            }), encoding="utf-8")
+            code = main(["evidence", "validate", str(bundle), "--schema", "-o", str(output)])
+            self.assertEqual(code, 1)
+            data = json.loads(output.read_text(encoding="utf-8"))
+            self.assertFalse(data["ok"])
+            self.assertEqual(data["validator"], "jsonschema Draft 2020-12")
 
 
 if __name__ == "__main__":

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 
-from repro_evidence_kit.evidence import validate_evidence_bundle
+from repro_evidence_kit.evidence import Draft202012Validator, validate_evidence_bundle, validate_evidence_bundle_schema
 
 
 class EvidenceTests(unittest.TestCase):
@@ -20,6 +21,38 @@ class EvidenceTests(unittest.TestCase):
         result = validate_evidence_bundle({"title": "Bad"})
         self.assertFalse(result["ok"])
         self.assertIn("missing top-level field: inputs", result["errors"])
+
+    @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
+    def test_schema_valid_bundle(self):
+        result = validate_evidence_bundle_schema({
+            "schema_version": "1.0",
+            "title": "Example",
+            "inputs": [{"path": "input.bin", "sha256": "a" * 64}],
+            "commands": [{"argv": ["tool", "input.bin"]}],
+            "outputs": [{"path": "output.bin", "sha256": "b" * 64}],
+        })
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["validator"], "jsonschema Draft 2020-12")
+
+    @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
+    def test_schema_catches_schema_only_sha_failure(self):
+        bundle = {
+            "schema_version": "1.0",
+            "title": "Example",
+            "inputs": [{"path": "input.bin", "sha256": "not-a-hex-digest"}],
+            "commands": [{"argv": ["tool", "input.bin"]}],
+            "outputs": [{"path": "output.bin", "sha256": "b" * 64}],
+        }
+        lightweight = validate_evidence_bundle(bundle)
+        schema_result = validate_evidence_bundle_schema(bundle)
+        self.assertTrue(lightweight["ok"])
+        self.assertFalse(schema_result["ok"])
+        self.assertTrue(any("sha256" in error for error in schema_result["errors"]))
+
+    def test_packaged_schema_matches_checked_in_schema(self):
+        repo_schema = Path("schemas/evidence-bundle.schema.json").read_text(encoding="utf-8")
+        packaged_schema = Path("src/repro_evidence_kit/schemas/evidence-bundle.schema.json").read_text(encoding="utf-8")
+        self.assertEqual(packaged_schema, repo_schema)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add optional JSON Schema-backed evidence bundle validation while keeping the existing lightweight validator as the default path.

## What changed

- Adds `repro-evidence evidence validate --schema`.
- Uses `schemas/evidence-bundle.schema.json` with the optional `jsonschema` dependency.
- Adds `schema` optional extra: `repro-evidence-kit[schema]`.
- Keeps default lightweight validation usable without optional dependencies.
- Packages a copy of the checked-in schema for installed CLI use and tests it stays in sync.
- Documents lightweight vs schema-backed validation modes.
- Updates CI to install the schema extra so schema tests run in GitHub Actions.

## Validation

- `uv run pytest -q` -> 22 passed
- `uv run --extra schema pytest -q` -> 22 passed
- Manual CLI smoke: invalid SHA-256 passes lightweight shape expectations but fails `--schema` with exit code 1.

Closes #1.
