### PR TITLE
[codex] Polish roadmap and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ repro-evidence manifest diff before.json before.json
 repro-evidence evidence validate examples/evidence-bundle.yaml
 ```
 
+For larger artifact trees, filter manifests with explicit include/exclude patterns:
+
+```bash
+repro-evidence manifest create artifacts --include reports --exclude "*.tmp" -o manifest.json
+```
+
+For stricter evidence-bundle checks, install the optional schema extra and validate against the checked-in JSON Schema:
+
+```bash
+pip install "repro-evidence-kit[schema]"
+repro-evidence evidence validate examples/evidence-bundle.yaml --schema
+```
+
 Sandbox verification compares a baseline manifest with an after-run manifest:
 
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,24 +1,26 @@
 # Roadmap
 
-## v0.1.x hardening
+## Recently completed
+
+These are implemented on `main` and are candidates for the next `v0.1.x` release:
+
+- Markdown output for `manifest diff` reports.
+- Include/exclude filters for large artifact-tree manifests.
+- Optional JSON Schema validation for evidence bundles.
+- Stable CLI exit-code documentation and regression coverage.
+- GitHub Actions cookbook and CI leakage audit.
+
+## Near-term polish
 
 - Keep examples synthetic-only.
-- Improve README and tutorials.
-- Add CI leakage audit and contribution templates.
-- Add small regression tests for CLI exit codes.
-
-## v0.2.0 candidate scope
-
-- Optional JSON Schema validation backend for evidence bundles.
-- Markdown report output for manifest diffs.
-- More GitHub Actions cookbook examples.
-- Stable machine-readable exit code documentation.
+- Improve README, tutorials, and cookbook examples as new workflows land.
+- Prepare compact release notes for the next `v0.1.x` release.
 
 ## Later ideas
 
 - SARIF or JUnit output for CI integrations.
-- Pluggable path filters for large artifact trees.
 - Signed evidence bundle support.
+- Additional CI cookbook recipes for schema validation and filtered manifests.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

Polish the public project surface after the recent maintainer issues landed.

## What changed

- Moves completed roadmap items out of future-candidate sections.
- Keeps remaining roadmap items focused on near-term polish and later integrations.
- Adds README quick-start examples for filtered manifests and schema-backed evidence validation.

## Validation

- `uv run --extra schema pytest -q` -> 22 passed

No release changes in this PR.
