### PR TITLE
[codex] Expand CI cookbook schema filter workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The command exits `0` when all changes are allowed and `1` when unexpected chang
 - [Tutorial](docs/tutorial.md)
 - [Evidence bundle format](docs/evidence-bundle-format.md)
 - [Maintainer workflow](docs/maintainer-workflow.md)
-- [GitHub Actions cookbook](docs/github-actions.md)
+- [GitHub Actions cookbook](docs/github-actions.md) — CI recipes for validation, manifests, sandbox checks, and schema-backed filtered workflows.
 - [Design principles](docs/design-principles.md)
 - [Roadmap](ROADMAP.md)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,12 +15,12 @@ These are implemented on `main` and are candidates for the next `v0.1.x` release
 - Keep examples synthetic-only.
 - Improve README, tutorials, and cookbook examples as new workflows land.
 - Prepare compact release notes for the next `v0.1.x` release.
+- Expand CI cookbook coverage for schema validation and filtered manifest workflows.
 
 ## Later ideas
 
 - SARIF or JUnit output for CI integrations.
 - Signed evidence bundle support.
-- Additional CI cookbook recipes for schema validation and filtered manifests.
 
 ## Non-goals
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -48,6 +48,50 @@ jobs:
           path: manifest.json
 ```
 
+
+## Combine schema validation with filtered manifests
+
+Use this recipe when a workflow produces a large artifact tree but reviewers only need a compact manifest for stable outputs plus schema-backed evidence metadata. The example creates synthetic files during the job and keeps the manifest target-neutral.
+
+```yaml
+name: Filtered evidence workflow
+
+on:
+  pull_request:
+
+jobs:
+  evidence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install -e ".[schema]"
+      - name: Create synthetic artifact tree
+        run: |
+          mkdir -p artifacts/reports artifacts/tmp
+          printf '%s\n' '{"ok": true}' > artifacts/reports/result.json
+          printf '%s\n' 'transient' > artifacts/tmp/cache.tmp
+      - name: Create filtered manifest
+        run: |
+          python -m repro_evidence_kit manifest create artifacts \
+            --include reports \
+            --exclude "*.tmp" \
+            -o filtered-manifest.json
+      - name: Validate evidence bundle with schema
+        run: |
+          python -m repro_evidence_kit evidence validate \
+            examples/evidence-bundle.yaml \
+            --schema
+      - uses: actions/upload-artifact@v4
+        with:
+          name: filtered-evidence
+          path: filtered-manifest.json
+```
+
+The schema extra installs `jsonschema` for `--schema`. The filtered manifest records only paths selected by the include/exclude rules, so large or transient directories can stay out of the review artifact without weakening the evidence-bundle validation step.
+
 ## Gate sandbox output changes
 
 ```yaml


### PR DESCRIPTION
## What changed

- Adds a GitHub Actions cookbook recipe that combines filtered manifest creation with schema-backed evidence validation.
- Keeps the recipe synthetic-only and target-neutral, with copy-pasteable placeholder artifact paths.
- Updates README documentation link text and ROADMAP placement for the cookbook expansion.

## Why

Issue #14 asked for a CI recipe showing the newly available filtered manifest and optional schema validation workflows together before the next v0.1.x release.

Closes #14.

## Validation

- `uv run pytest -q` -> 22 passed
- `uv run --extra schema pytest -q` -> 22 passed
- Manual smoke of the cookbook commands produced a filtered manifest with `reports/result.json` only and schema validation returned `ok: true`.
