### PR TITLE
[codex] Prepare v0.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
+## 0.1.2 - 2026-06-02
+
 - Add optional JSON Schema validation for evidence bundles.
 - Add include/exclude filters for manifest creation.
 - Add Markdown output for `manifest diff` reports.
 - Document stable CLI exit-code meanings and add regression coverage.
-- Add a small GitHub Actions cookbook for maintainer CI usage.
+- Expand GitHub Actions cookbook coverage for schema-backed filtered manifest workflows.
 - Clarify source-based installation until a package index release exists.
 
 ## 0.1.1 - 2026-05-31

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The project is intentionally target-neutral. It should help maintainers in CI, s
 Until a package index release is published, install from the repository:
 
 ```bash
-pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.1.1"
+pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.1.2"
 ```
 
 For local development:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repro-evidence-kit"
-version = "0.1.1"
+version = "0.1.2"
 description = "Reproducible artifact manifests, sandbox-output verification, and evidence-bundle validation."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/repro_evidence_kit/__init__.py
+++ b/src/repro_evidence_kit/__init__.py
@@ -1,3 +1,3 @@
 """Reproducible artifact evidence toolkit."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -23,7 +23,7 @@ def _csv_list(values: list[str] | None) -> list[str]:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="repro-evidence", description="Reproducible artifact manifest and evidence-bundle tools.")
-    parser.add_argument("--version", action="version", version="repro-evidence 0.1.1")
+    parser.add_argument("--version", action="version", version="repro-evidence 0.1.2")
     sub = parser.add_subparsers(dest="command", required=True)
 
     manifest = sub.add_parser("manifest", help="Create or compare file manifests")


### PR DESCRIPTION
## What changed

- Bumps package and CLI version metadata to `0.1.2`.
- Moves the accumulated Unreleased notes into `0.1.2 - 2026-06-02`.
- Updates the README source-install tag to `v0.1.2`.

## Why

This prepares the release after the merged v0.1.x feature and cookbook work.

## Validation

- `uv run python -m repro_evidence_kit --version` -> `repro-evidence 0.1.2`
- `uv run pytest -q` -> 22 passed
- `uv run --extra schema pytest -q` -> 22 passed
