### PR TITLE
[codex] Add JUnit sandbox verification output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add JUnit XML output for `verify sandbox-run` CI report consumers.
+
 ## 0.1.2 - 2026-06-02
 
 - Add optional JSON Schema validation for evidence bundles.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The project is intentionally target-neutral. It should help maintainers in CI, s
 
 - Create deterministic SHA-256 manifests for files or filtered directory trees.
 - Diff two manifests to identify added, removed, changed, and unchanged artifacts.
-- Verify sandbox/experiment outputs against explicit allowlists.
+- Verify sandbox/experiment outputs against explicit allowlists, with optional JUnit XML for CI report consumers.
 - Validate simple YAML or JSON evidence bundles, with optional JSON Schema checks.
 - Includes only synthetic public examples.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ These are implemented on `main` and are candidates for the next `v0.1.x` release
 
 ## Later ideas
 
-- SARIF or JUnit output for CI integrations.
+- SARIF output for CI code-scanning integrations.
 - Signed evidence bundle support.
 
 ## Non-goals

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,6 +68,17 @@ Comma-separated allowlists are accepted for added, changed, and removed paths.
 
 Allowlist paths use the same normalization as manifest diffs, so `reports\summary.json` and `reports/summary.json` match the same logical artifact.
 
+Use `--format junit` when a CI system or test-report action expects JUnit XML:
+
+```bash
+repro-evidence verify sandbox-run before.json after.json \
+  --allow-added report.json \
+  --format junit \
+  -o sandbox-verification.xml
+```
+
+The JUnit report has one testcase named `sandbox-run`. Unexpected added, changed, or removed paths are rendered as one failure. This is a CI reporting adapter for the sandbox verification predicate; it is not a full test suite and does not change the JSON output contract.
+
 ## `evidence validate`
 
 Validate a YAML or JSON evidence bundle.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -48,7 +48,6 @@ jobs:
           path: manifest.json
 ```
 
-
 ## Combine schema validation with filtered manifests
 
 Use this recipe when a workflow produces a large artifact tree but reviewers only need a compact manifest for stable outputs plus schema-backed evidence metadata. The example creates synthetic files during the job and keeps the manifest target-neutral.
@@ -117,3 +116,41 @@ jobs:
 ```
 
 Unexpected added, changed, or removed paths produce exit code `1`, which fails the job as a policy failure.
+
+## Upload sandbox verification as JUnit XML
+
+Use this when your CI dashboard or a test-report action can display JUnit XML. GitHub Actions does not render JUnit XML by itself, so this recipe uploads the report as an artifact and leaves rendering to your chosen report consumer.
+
+```yaml
+name: Sandbox verification report
+
+on:
+  pull_request:
+
+jobs:
+  verify-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install -e .
+      - run: mkdir -p sandbox && printf 'input\n' > sandbox/input.txt
+      - run: python -m repro_evidence_kit manifest create sandbox -o before.json
+      - run: printf '{"ok": true}\n' > sandbox/report.json
+      - run: python -m repro_evidence_kit manifest create sandbox -o after.json
+      - name: Write JUnit report
+        run: |
+          python -m repro_evidence_kit verify sandbox-run before.json after.json \
+            --allow-added report.json \
+            --format junit \
+            -o sandbox-verification.xml
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sandbox-verification-junit
+          path: sandbox-verification.xml
+```
+
+The JUnit output keeps the same exit-code behavior as JSON: unexpected changes still return `1` and fail the job. The XML report contains one testcase and one failure when the sandbox predicate fails.

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from .evidence import load_evidence, validate_evidence_bundle, validate_evidence_bundle_schema
 from .manifest import create_manifest, diff_manifests, load_json, write_json, write_text
-from .verify import verify_sandbox_output
+from .verify import sandbox_result_as_junit, verify_sandbox_output
 
 
 def _csv_set(value: str | None) -> set[str]:
@@ -49,6 +49,7 @@ def build_parser() -> argparse.ArgumentParser:
     sandbox.add_argument("--allow-added", help="Comma-separated path allowlist")
     sandbox.add_argument("--allow-changed", help="Comma-separated path allowlist")
     sandbox.add_argument("--allow-removed", help="Comma-separated path allowlist")
+    sandbox.add_argument("--format", choices=("json", "junit"), default="json")
     sandbox.add_argument("-o", "--output", type=Path)
 
     evidence = sub.add_parser("evidence", help="Validate evidence bundles")
@@ -90,7 +91,10 @@ def main(argv: list[str] | None = None) -> int:
                 allow_changed=_csv_set(args.allow_changed),
                 allow_removed=_csv_set(args.allow_removed),
             )
-            write_json(result, args.output)
+            if args.format == "junit":
+                write_text(sandbox_result_as_junit(result), args.output)
+            else:
+                write_json(result, args.output)
             return 0 if result["ok"] else 1
         if args.command == "evidence" and args.evidence_command == "validate":
             bundle = load_evidence(args.bundle)

--- a/src/repro_evidence_kit/verify.py
+++ b/src/repro_evidence_kit/verify.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import xml.etree.ElementTree as ET
 from typing import Any
 
 from .manifest import diff_manifests, normalize_manifest_path
@@ -28,3 +30,22 @@ def verify_sandbox_output(before: dict[str, Any], after: dict[str, Any], *, allo
             "removed": sorted(allow_removed),
         },
     }
+
+
+def sandbox_result_as_junit(result: dict[str, Any]) -> str:
+    """Render a sandbox verification result as a minimal JUnit XML report."""
+    ok = bool(result.get("ok"))
+    suite = ET.Element(
+        "testsuite",
+        {
+            "name": "repro-evidence sandbox-run",
+            "tests": "1",
+            "failures": "0" if ok else "1",
+            "errors": "0",
+        },
+    )
+    case = ET.SubElement(suite, "testcase", {"classname": "repro_evidence_kit.verify", "name": "sandbox-run"})
+    if not ok:
+        failure = ET.SubElement(case, "failure", {"message": "unexpected sandbox output changes"})
+        failure.text = json.dumps(result.get("unexpected", {}), indent=2, sort_keys=True)
+    return ET.tostring(suite, encoding="unicode") + "\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import contextlib
 import io
 import json
 import tempfile
+import xml.etree.ElementTree as ET
 import unittest
 from pathlib import Path
 
@@ -101,6 +102,23 @@ class CliTests(unittest.TestCase):
             self.assertEqual([item["path"] for item in data["files"]], ["reports/keep.txt"])
             self.assertEqual(data["filters"]["include"], ["reports"])
             self.assertEqual(data["filters"]["exclude"], ["*.log"])
+
+    def test_verify_sandbox_junit_output_keeps_failure_exit_code(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            before = root / "before.json"
+            after = root / "after.json"
+            output = root / "verify.xml"
+            before.write_text(json.dumps({"files": []}), encoding="utf-8")
+            after.write_text(
+                json.dumps({"files": [{"path": "report.json", "size": 2, "sha256": "a" * 64}]}),
+                encoding="utf-8",
+            )
+            code = main(["verify", "sandbox-run", str(before), str(after), "--format", "junit", "-o", str(output)])
+            self.assertEqual(code, 1)
+            root_xml = ET.fromstring(output.read_text(encoding="utf-8"))
+            self.assertEqual(root_xml.attrib["failures"], "1")
+            self.assertIn("report.json", root_xml.findtext("./testcase/failure") or "")
 
     @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
     def test_evidence_validate_schema_cli_returns_1_for_schema_failure(self):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import unittest
+import xml.etree.ElementTree as ET
 
-from repro_evidence_kit.verify import verify_sandbox_output
+from repro_evidence_kit.verify import sandbox_result_as_junit, verify_sandbox_output
 
 
 class VerifyTests(unittest.TestCase):
@@ -25,6 +26,24 @@ class VerifyTests(unittest.TestCase):
         result = verify_sandbox_output(before, after, allow_added={"reports/summary.json"})
         self.assertTrue(result["ok"])
         self.assertEqual(result["allowed"]["added"], ["reports/summary.json"])
+
+    def test_sandbox_result_as_junit_reports_failure_for_unexpected_changes(self):
+        result = {
+            "ok": False,
+            "unexpected": {"added": ["report.json"], "changed": [], "removed": []},
+        }
+        root = ET.fromstring(sandbox_result_as_junit(result))
+        self.assertEqual(root.tag, "testsuite")
+        self.assertEqual(root.attrib["tests"], "1")
+        self.assertEqual(root.attrib["failures"], "1")
+        failure = root.find("./testcase/failure")
+        self.assertIsNotNone(failure)
+        self.assertIn("report.json", failure.text or "")
+
+    def test_sandbox_result_as_junit_reports_success_without_failure(self):
+        root = ET.fromstring(sandbox_result_as_junit({"ok": True, "unexpected": {}}))
+        self.assertEqual(root.attrib["failures"], "0")
+        self.assertIsNone(root.find("./testcase/failure"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Adds `--format junit` to `repro-evidence verify sandbox-run`.
- Renders sandbox verification as a minimal JUnit XML report with one testcase.
- Keeps the existing JSON output and exit-code behavior unchanged.
- Documents the CI consumer and limitation: this is a test-report adapter for sandbox verification, not a full test suite.
- Adds synthetic unit and CLI coverage.

## Why

CI users often need a machine-readable report format that can be uploaded to or rendered by test report consumers. This implements the narrow first format requested in issue #12.

Closes #12.

## Validation

- `uv run python -m unittest tests.test_verify tests.test_cli -v` -> 13 tests passed
- `uv run pytest -q` -> 25 passed
- `uv run --extra schema pytest -q` -> 25 passed
- Manual CLI smoke: `verify sandbox-run --format junit` returned exit `1` for unexpected output and wrote a JUnit XML failure containing `report.json`.
