### PR TITLE
[codex] Document signed bundle design boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add JUnit XML output for `verify sandbox-run` CI report consumers.
+- Add a signed evidence bundles design note that defines the sidecar-first support boundary.
 
 ## 0.1.2 - 2026-06-02
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The command exits `0` when all changes are allowed and `1` when unexpected chang
 - [CLI reference](docs/cli.md)
 - [Tutorial](docs/tutorial.md)
 - [Evidence bundle format](docs/evidence-bundle-format.md)
+- [Signed evidence bundles design note](docs/signed-bundles.md)
 - [Maintainer workflow](docs/maintainer-workflow.md)
 - [GitHub Actions cookbook](docs/github-actions.md) — CI recipes for validation, manifests, sandbox checks, and schema-backed filtered workflows.
 - [Design principles](docs/design-principles.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ These are implemented on `main` and are candidates for the next `v0.1.x` release
 ## Later ideas
 
 - SARIF output for CI code-scanning integrations.
-- Signed evidence bundle support.
+- Signed evidence bundle implementation after the sidecar design note is reviewed.
 
 ## Non-goals
 

--- a/docs/evidence-bundle-format.md
+++ b/docs/evidence-bundle-format.md
@@ -29,3 +29,8 @@ The format is intentionally small. It is not a provenance database and does not 
 `repro-evidence evidence validate BUNDLE --schema` uses `schemas/evidence-bundle.schema.json` through the optional `jsonschema` dependency. Use schema-backed validation in CI when maintainers want stricter contract checks such as SHA-256 hex formatting and numeric bounds.
 
 The schema path can be overridden for local experiments with `--schema-path`, but repository CI should use the checked-in schema by default.
+
+
+## Signed bundle design
+
+Unsigned evidence bundles remain the stable default. Optional signed-bundle support is being scoped in [Signed evidence bundles design note](signed-bundles.md). The design keeps signatures as a sidecar concept first so validation can continue to support unsigned bundles without a breaking schema change.

--- a/docs/signed-bundles.md
+++ b/docs/signed-bundles.md
@@ -1,0 +1,99 @@
+# Signed evidence bundles design note
+
+Signed bundle support should let a maintainer check that an evidence bundle record has not changed since it was signed. It must not imply that the recorded command was run correctly, that artifacts are semantically correct, or that a private input can be trusted without review.
+
+## Current status
+
+This is a design note, not an implemented signing backend. Unsigned evidence bundles remain fully supported.
+
+## Goals
+
+- Add an optional workflow for signing an evidence bundle after it has been authored and validated.
+- Let a reviewer verify the signed bundle bytes against a public key or trusted local key reference.
+- Keep the workflow target-neutral and usable with synthetic examples.
+- Keep failure modes explicit: invalid structure, invalid signature, missing key material, and unsupported signing metadata should be distinguishable.
+
+## Non-goals
+
+- No live private keys, real maintainer keys, or committed secrets.
+- No external keyserver requirement.
+- No claim that signatures prove artifact semantics or command correctness.
+- No requirement that all evidence bundles be signed.
+- No target-specific policy, private path, proprietary sample, or reverse-engineering fixture.
+
+## What signing proves
+
+A valid signature can prove that the exact canonical bundle payload was signed by the holder of the matching private key.
+
+It can help answer:
+
+- Did this evidence bundle change after the signer approved it?
+- Does this bundle match the public key or local trust material used by the reviewer?
+- Is the bundle metadata stable enough to attach to a pull request, release note, or audit record?
+
+## What signing does not prove
+
+A valid signature does not prove:
+
+- the command actually ran;
+- the command was safe;
+- the outputs are semantically correct;
+- the hashes correspond to private data the reviewer cannot inspect;
+- the signer identity is trustworthy without an external trust decision;
+- the signing key has not been compromised.
+
+## Proposed bundle shape
+
+Unsigned bundles should keep the existing format. A signed workflow can write a sidecar first, avoiding a breaking change to the bundle schema:
+
+```text
+evidence-bundle.yaml
+evidence-bundle.yaml.sig.json
+```
+
+A sidecar keeps signatures optional and avoids mutating the payload after signing.
+
+Candidate sidecar fields:
+
+```json
+{
+  "signature_version": "1.0",
+  "payload_path": "evidence-bundle.yaml",
+  "payload_sha256": "<sha256 of canonical payload bytes>",
+  "algorithm": "<algorithm identifier>",
+  "key_hint": "<local or public key identifier>",
+  "signature": "<encoded signature bytes>"
+}
+```
+
+## Canonical payload rule
+
+The first implementation should sign exact file bytes or a clearly documented canonical serialization, not an implicit Python object. Exact file bytes are simpler and reduce surprise, but they make whitespace and key ordering part of the signed payload. If canonical serialization is chosen later, it must be documented and covered by round-trip tests before release.
+
+## CLI sketch
+
+Potential commands:
+
+```bash
+repro-evidence evidence sign evidence-bundle.yaml \
+  --key local-test-key.pem \
+  -o evidence-bundle.yaml.sig.json
+
+repro-evidence evidence verify-signature evidence-bundle.yaml \
+  --signature evidence-bundle.yaml.sig.json \
+  --key local-test-public-key.pem
+```
+
+The command names are provisional. The implementation should keep `evidence validate` unchanged and allow unsigned bundles to keep passing validation.
+
+## Test fixture policy
+
+If tests need key material, use local synthetic test keys only. Test keys must be labeled as fixtures and must not be suitable for real trust decisions.
+
+## Recommended implementation path
+
+1. Add parser and data model support for signature sidecars without changing unsigned bundle validation.
+2. Add synthetic fixture tests for malformed sidecars and payload hash mismatches.
+3. Add one signing backend with local test keys only.
+4. Document reviewer setup and limitations before adding release notes.
+5. Consider richer trust policies only after the sidecar contract is stable.


### PR DESCRIPTION
## What changed

- Adds a signed evidence bundles design note.
- Defines sidecar-first signing as the preferred safe direction.
- Documents what signatures prove and do not prove.
- Keeps unsigned evidence bundles as the stable default.
- Updates README, evidence bundle docs, roadmap, and changelog.

## Why

Issue #13 explicitly asks to start with a design note or minimal prototype before committing to a signing backend. This PR establishes the support boundary without introducing live secrets, real private keys, keyserver assumptions, or semantic-correctness claims.

Refs #13.

## Validation

- `uv run pytest -q` -> 25 passed
- `uv run --extra schema pytest -q` -> 25 passed
- Leakage audit grep used by CI passed locally with `.git`, `.venv`, and `.pytest_cache` excluded.

## Not implemented here

- No signing backend.
- No key handling.
- No signature verification command.
- No change to unsigned bundle validation.
