### PR TITLE
[codex] Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.0 - 2026-06-02
+
 - Add JUnit XML output for `verify sandbox-run` CI report consumers.
 - Add a signed evidence bundles design note that defines the sidecar-first support boundary.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The project is intentionally target-neutral. It should help maintainers in CI, s
 Until a package index release is published, install from the repository:
 
 ```bash
-pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.1.2"
+pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.2.0"
 ```
 
 For local development:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repro-evidence-kit"
-version = "0.1.2"
+version = "0.2.0"
 description = "Reproducible artifact manifests, sandbox-output verification, and evidence-bundle validation."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/repro_evidence_kit/__init__.py
+++ b/src/repro_evidence_kit/__init__.py
@@ -1,3 +1,3 @@
 """Reproducible artifact evidence toolkit."""
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -23,7 +23,7 @@ def _csv_list(values: list[str] | None) -> list[str]:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="repro-evidence", description="Reproducible artifact manifest and evidence-bundle tools.")
-    parser.add_argument("--version", action="version", version="repro-evidence 0.1.2")
+    parser.add_argument("--version", action="version", version="repro-evidence 0.2.0")
     sub = parser.add_subparsers(dest="command", required=True)
 
     manifest = sub.add_parser("manifest", help="Create or compare file manifests")


### PR DESCRIPTION
## What changed

- Bumps package and CLI version metadata to `0.2.0`.
- Moves the JUnit sandbox report and signed-bundle design notes into `0.2.0 - 2026-06-02`.
- Updates the README source-install tag to `v0.2.0`.

## Why

This packages the post-`v0.1.2` CI-output work and signed-bundle design boundary into the next minor release.

## Validation

- `uv run python -m repro_evidence_kit --version` -> `repro-evidence 0.2.0`
- `uv run --extra schema pytest -q` -> 25 passed
