### PR TITLE
[codex] Add signed bundle sidecar prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The project is intentionally target-neutral. It should help maintainers in CI, s
 - Diff two manifests to identify added, removed, changed, and unchanged artifacts.
 - Verify sandbox/experiment outputs against explicit allowlists, with optional JUnit XML for CI report consumers.
 - Validate simple YAML or JSON evidence bundles, with optional JSON Schema checks.
+- Sign and verify evidence bundle sidecars with a local-key tamper-detection prototype.
 - Includes only synthetic public examples.
 
 ## Install
@@ -65,6 +66,15 @@ For stricter evidence-bundle checks, install the optional schema extra and valid
 ```bash
 pip install "repro-evidence-kit[schema]"
 repro-evidence evidence validate examples/evidence-bundle.yaml --schema
+```
+
+
+Signed bundle sidecars are optional. For a local tamper-detection prototype, create or provide local trust material and keep it out of git:
+
+```bash
+printf 'synthetic local test key only\n' > local-test.key
+repro-evidence evidence sign examples/evidence-bundle.yaml --key local-test.key -o evidence-bundle.yaml.sig.json
+repro-evidence evidence verify-signature examples/evidence-bundle.yaml --signature evidence-bundle.yaml.sig.json --key local-test.key
 ```
 
 Sandbox verification compares a baseline manifest with an after-run manifest:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,25 +2,26 @@
 
 ## Recently completed
 
-These are implemented on `main` and are candidates for the next `v0.1.x` release:
+These are implemented on `main` after `v0.2.0` and are candidates for the next release:
 
 - Markdown output for `manifest diff` reports.
 - Include/exclude filters for large artifact-tree manifests.
 - Optional JSON Schema validation for evidence bundles.
 - Stable CLI exit-code documentation and regression coverage.
 - GitHub Actions cookbook and CI leakage audit.
+- Minimal signed evidence bundle sidecar prototype.
 
 ## Near-term polish
 
 - Keep examples synthetic-only.
 - Improve README, tutorials, and cookbook examples as new workflows land.
-- Prepare compact release notes for the next `v0.1.x` release.
+- Prepare compact release notes for the next release.
 - Expand CI cookbook coverage for schema validation and filtered manifest workflows.
 
 ## Later ideas
 
 - SARIF output for CI code-scanning integrations.
-- Signed evidence bundle implementation after the sidecar design note is reviewed.
+- Richer signed bundle trust policies after the sidecar contract is stable.
 
 ## Non-goals
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,3 +99,29 @@ repro-evidence evidence validate examples/evidence-bundle.yaml --schema
 Schema-backed validation uses `schemas/evidence-bundle.schema.json` and additionally enforces constraints such as SHA-256 hex format and numeric size bounds. Use `--schema-path custom.schema.json` with `--schema` to test a local schema variant.
 
 Exit code `1` means the file was read successfully but the bundle failed validation. Exit code `2` means the file could not be read, parsed, or schema validation was requested without the optional dependency.
+
+
+## `evidence sign`
+
+Sign the exact evidence bundle file bytes with a local HMAC key and write a sidecar JSON file.
+
+```bash
+repro-evidence evidence sign examples/evidence-bundle.yaml \
+  --key local-test.key \
+  --key-hint local-test \
+  -o examples/evidence-bundle.yaml.sig.json
+```
+
+The key file is local trust material. Do not commit live secrets or real maintainer private keys. The prototype algorithm is `hmac-sha256`, intended for local tamper detection and synthetic examples.
+
+## `evidence verify-signature`
+
+Verify that a sidecar signature still matches the exact evidence bundle bytes and local key.
+
+```bash
+repro-evidence evidence verify-signature examples/evidence-bundle.yaml \
+  --signature examples/evidence-bundle.yaml.sig.json \
+  --key local-test.key
+```
+
+Exit code `0` means the sidecar signature matches. Exit code `1` means the sidecar was read but the payload hash, signature, version, or algorithm check failed. Exit code `2` means the command could not read or parse an input. A valid signature does not prove command execution, artifact semantics, or signer identity beyond the reviewer's trust in the local key.

--- a/docs/signed-bundles.md
+++ b/docs/signed-bundles.md
@@ -9,13 +9,13 @@ A minimal local-key prototype is implemented. It writes a JSON sidecar and signs
 ## Goals
 
 - Add an optional workflow for signing an evidence bundle after it has been authored and validated.
-- Let a reviewer verify the signed bundle bytes against a public key or trusted local key reference.
+- Let a reviewer verify the signed bundle bytes against trusted local key material or a non-secret key reference.
 - Keep the workflow target-neutral and usable with synthetic examples.
 - Keep failure modes explicit: invalid structure, invalid signature, missing key material, and unsupported signing metadata should be distinguishable.
 
 ## Non-goals
 
-- No live private keys, real maintainer keys, or committed secrets.
+- No live keys, real maintainer trust material, or committed secrets.
 - No external keyserver requirement.
 - No claim that signatures prove artifact semantics or command correctness.
 - No requirement that all evidence bundles be signed.
@@ -23,12 +23,12 @@ A minimal local-key prototype is implemented. It writes a JSON sidecar and signs
 
 ## What signing proves
 
-A valid signature can prove that the exact canonical bundle payload was signed by the holder of the matching private key.
+For the current `hmac-sha256` prototype, a valid sidecar can prove that the exact bundle bytes still match the local shared key material used for signing and verification.
 
 It can help answer:
 
 - Did this evidence bundle change after the signer approved it?
-- Does this bundle match the public key or local trust material used by the reviewer?
+- Does this bundle match the local trust material used by the reviewer?
 - Is the bundle metadata stable enough to attach to a pull request, release note, or audit record?
 
 ## What signing does not prove
@@ -61,7 +61,7 @@ Candidate sidecar fields:
   "payload_path": "evidence-bundle.yaml",
   "payload_sha256": "<sha256 of canonical payload bytes>",
   "algorithm": "hmac-sha256",
-  "key_hint": "<local or public key identifier>",
+  "key_hint": "<non-secret local key identifier>",
   "signature": "<hex HMAC-SHA256 signature>"
 }
 ```

--- a/docs/signed-bundles.md
+++ b/docs/signed-bundles.md
@@ -4,7 +4,7 @@ Signed bundle support should let a maintainer check that an evidence bundle reco
 
 ## Current status
 
-This is a design note, not an implemented signing backend. Unsigned evidence bundles remain fully supported.
+A minimal local-key prototype is implemented. It writes a JSON sidecar and signs the exact evidence bundle file bytes with `hmac-sha256`. Unsigned evidence bundles remain fully supported.
 
 ## Goals
 
@@ -60,9 +60,9 @@ Candidate sidecar fields:
   "signature_version": "1.0",
   "payload_path": "evidence-bundle.yaml",
   "payload_sha256": "<sha256 of canonical payload bytes>",
-  "algorithm": "<algorithm identifier>",
+  "algorithm": "hmac-sha256",
   "key_hint": "<local or public key identifier>",
-  "signature": "<encoded signature bytes>"
+  "signature": "<hex HMAC-SHA256 signature>"
 }
 ```
 
@@ -70,21 +70,22 @@ Candidate sidecar fields:
 
 The first implementation should sign exact file bytes or a clearly documented canonical serialization, not an implicit Python object. Exact file bytes are simpler and reduce surprise, but they make whitespace and key ordering part of the signed payload. If canonical serialization is chosen later, it must be documented and covered by round-trip tests before release.
 
-## CLI sketch
+## CLI
 
-Potential commands:
+Prototype commands:
 
 ```bash
 repro-evidence evidence sign evidence-bundle.yaml \
-  --key local-test-key.pem \
+  --key local-test.key \
+  --key-hint local-test \
   -o evidence-bundle.yaml.sig.json
 
 repro-evidence evidence verify-signature evidence-bundle.yaml \
   --signature evidence-bundle.yaml.sig.json \
-  --key local-test-public-key.pem
+  --key local-test.key
 ```
 
-The command names are provisional. The implementation should keep `evidence validate` unchanged and allow unsigned bundles to keep passing validation.
+The prototype uses a local shared key file so it can run without external services or committed secrets. It is useful for tamper detection with locally trusted key material, not for public identity or certificate-chain validation. `evidence validate` remains unchanged and unsigned bundles keep passing validation.
 
 ## Test fixture policy
 
@@ -94,6 +95,6 @@ If tests need key material, use local synthetic test keys only. Test keys must b
 
 1. Add parser and data model support for signature sidecars without changing unsigned bundle validation.
 2. Add synthetic fixture tests for malformed sidecars and payload hash mismatches.
-3. Add one signing backend with local test keys only.
+3. Add one signing backend with local test keys only. Done for `hmac-sha256`.
 4. Document reviewer setup and limitations before adding release notes.
 5. Consider richer trust policies only after the sidecar contract is stable.

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .evidence import load_evidence, validate_evidence_bundle, validate_evidence_bundle_schema
 from .manifest import create_manifest, diff_manifests, load_json, write_json, write_text
+from .signing import load_signature_sidecar, sign_bundle, verify_bundle_signature
 from .verify import sandbox_result_as_junit, verify_sandbox_output
 
 
@@ -52,13 +53,25 @@ def build_parser() -> argparse.ArgumentParser:
     sandbox.add_argument("--format", choices=("json", "junit"), default="json")
     sandbox.add_argument("-o", "--output", type=Path)
 
-    evidence = sub.add_parser("evidence", help="Validate evidence bundles")
+    evidence = sub.add_parser("evidence", help="Validate and sign evidence bundles")
     evidence_sub = evidence.add_subparsers(dest="evidence_command", required=True)
     val = evidence_sub.add_parser("validate", help="Validate an evidence bundle YAML/JSON file")
     val.add_argument("bundle", type=Path)
     val.add_argument("--schema", action="store_true", help="Validate with schemas/evidence-bundle.schema.json using the optional jsonschema dependency")
     val.add_argument("--schema-path", type=Path, help="Use a custom JSON Schema path with --schema")
     val.add_argument("-o", "--output", type=Path)
+
+    sign = evidence_sub.add_parser("sign", help="Sign exact evidence bundle bytes with a local key")
+    sign.add_argument("bundle", type=Path)
+    sign.add_argument("--key", required=True, type=Path, help="Local synthetic or trusted HMAC key file")
+    sign.add_argument("--key-hint", help="Non-secret key identifier to record in the sidecar")
+    sign.add_argument("-o", "--output", type=Path, required=True)
+
+    verify_sig = evidence_sub.add_parser("verify-signature", help="Verify an evidence bundle signature sidecar")
+    verify_sig.add_argument("bundle", type=Path)
+    verify_sig.add_argument("--signature", required=True, type=Path, help="Signature sidecar JSON")
+    verify_sig.add_argument("--key", required=True, type=Path, help="Local synthetic or trusted HMAC key file")
+    verify_sig.add_argument("-o", "--output", type=Path)
     return parser
 
 
@@ -99,6 +112,13 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "evidence" and args.evidence_command == "validate":
             bundle = load_evidence(args.bundle)
             result = validate_evidence_bundle_schema(bundle, args.schema_path) if args.schema else validate_evidence_bundle(bundle)
+            write_json(result, args.output)
+            return 0 if result["ok"] else 1
+        if args.command == "evidence" and args.evidence_command == "sign":
+            write_json(sign_bundle(args.bundle, args.key, key_hint=args.key_hint), args.output)
+            return 0
+        if args.command == "evidence" and args.evidence_command == "verify-signature":
+            result = verify_bundle_signature(args.bundle, load_signature_sidecar(args.signature), args.key)
             write_json(result, args.output)
             return 0 if result["ok"] else 1
     except Exception as exc:

--- a/src/repro_evidence_kit/signing.py
+++ b/src/repro_evidence_kit/signing.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any
+
+SIGNATURE_VERSION = "1.0"
+ALGORITHM = "hmac-sha256"
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def load_key(path: Path) -> bytes:
+    key = path.read_bytes()
+    if not key:
+        raise ValueError(f"signing key is empty: {path}")
+    return key
+
+
+def load_signature_sidecar(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("signature sidecar must be a JSON object")
+    return data
+
+
+def sign_bundle(bundle_path: Path, key_path: Path, *, key_hint: str | None = None) -> dict[str, Any]:
+    payload = bundle_path.read_bytes()
+    key = load_key(key_path)
+    signature = hmac.new(key, payload, hashlib.sha256).hexdigest()
+    return {
+        "signature_version": SIGNATURE_VERSION,
+        "payload_path": bundle_path.name,
+        "payload_sha256": sha256_bytes(payload),
+        "algorithm": ALGORITHM,
+        "key_hint": key_hint or key_path.name,
+        "signature": signature,
+    }
+
+
+def verify_bundle_signature(bundle_path: Path, sidecar: dict[str, Any], key_path: Path) -> dict[str, Any]:
+    errors: list[str] = []
+    if sidecar.get("signature_version") != SIGNATURE_VERSION:
+        errors.append("unsupported signature_version")
+    if sidecar.get("algorithm") != ALGORITHM:
+        errors.append("unsupported algorithm")
+
+    payload = bundle_path.read_bytes()
+    payload_sha256 = sha256_bytes(payload)
+    if sidecar.get("payload_sha256") != payload_sha256:
+        errors.append("payload_sha256 mismatch")
+
+    signature = sidecar.get("signature")
+    if not isinstance(signature, str) or not signature:
+        errors.append("missing signature")
+    else:
+        expected = hmac.new(load_key(key_path), payload, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(signature, expected):
+            errors.append("signature mismatch")
+
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "algorithm": sidecar.get("algorithm"),
+        "payload_sha256": payload_sha256,
+        "key_hint": sidecar.get("key_hint"),
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,6 +120,55 @@ class CliTests(unittest.TestCase):
             self.assertEqual(root_xml.attrib["failures"], "1")
             self.assertIn("report.json", root_xml.findtext("./testcase/failure") or "")
 
+    def test_evidence_sign_and_verify_signature_cli(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "bundle.yaml"
+            key = root / "local-test.key"
+            signature = root / "bundle.yaml.sig.json"
+            verify_output = root / "verify-signature.json"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+
+            sign_code = main(["evidence", "sign", str(bundle), "--key", str(key), "--key-hint", "local-test", "-o", str(signature)])
+            verify_code = main([
+                "evidence",
+                "verify-signature",
+                str(bundle),
+                "--signature",
+                str(signature),
+                "--key",
+                str(key),
+                "-o",
+                str(verify_output),
+            ])
+
+            self.assertEqual(sign_code, 0)
+            self.assertEqual(verify_code, 0)
+            sidecar = json.loads(signature.read_text(encoding="utf-8"))
+            result = json.loads(verify_output.read_text(encoding="utf-8"))
+            self.assertEqual(sidecar["algorithm"], "hmac-sha256")
+            self.assertTrue(result["ok"])
+
+    def test_evidence_verify_signature_cli_returns_1_for_payload_mismatch(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "bundle.yaml"
+            key = root / "local-test.key"
+            signature = root / "bundle.yaml.sig.json"
+            output = root / "verify-signature.json"
+            bundle.write_text("title: Before\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+            self.assertEqual(main(["evidence", "sign", str(bundle), "--key", str(key), "-o", str(signature)]), 0)
+            bundle.write_text("title: After\n", encoding="utf-8")
+
+            code = main(["evidence", "verify-signature", str(bundle), "--signature", str(signature), "--key", str(key), "-o", str(output)])
+
+            self.assertEqual(code, 1)
+            result = json.loads(output.read_text(encoding="utf-8"))
+            self.assertFalse(result["ok"])
+            self.assertIn("payload_sha256 mismatch", result["errors"])
+
     @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
     def test_evidence_validate_schema_cli_returns_1_for_schema_failure(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from repro_evidence_kit.signing import sign_bundle, verify_bundle_signature
+
+
+class SigningTests(unittest.TestCase):
+    def test_sign_and_verify_exact_bundle_bytes(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "evidence-bundle.yaml"
+            key = root / "local-test.key"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+
+            sidecar = sign_bundle(bundle, key, key_hint="local-test")
+            result = verify_bundle_signature(bundle, sidecar, key)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(sidecar["signature_version"], "1.0")
+        self.assertEqual(sidecar["algorithm"], "hmac-sha256")
+        self.assertEqual(sidecar["payload_path"], "evidence-bundle.yaml")
+        self.assertEqual(sidecar["key_hint"], "local-test")
+
+    def test_verify_rejects_changed_payload(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "evidence-bundle.yaml"
+            key = root / "local-test.key"
+            bundle.write_text("title: Before\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+            sidecar = sign_bundle(bundle, key)
+
+            bundle.write_text("title: After\n", encoding="utf-8")
+            result = verify_bundle_signature(bundle, sidecar, key)
+
+        self.assertFalse(result["ok"])
+        self.assertIn("payload_sha256 mismatch", result["errors"])
+        self.assertIn("signature mismatch", result["errors"])
+
+    def test_verify_rejects_unsupported_algorithm(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "evidence-bundle.yaml"
+            key = root / "local-test.key"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+            sidecar = sign_bundle(bundle, key)
+            sidecar["algorithm"] = "unknown"
+
+            result = verify_bundle_signature(bundle, sidecar, key)
+
+        self.assertFalse(result["ok"])
+        self.assertIn("unsupported algorithm", result["errors"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a minimal signed evidence bundle sidecar prototype for issue #13
- add `evidence sign` and `evidence verify-signature` CLI commands using exact bundle bytes and a local `hmac-sha256` key
- document the prototype boundaries: unsigned bundles still work, keys stay local, and signatures do not prove command execution or artifact semantics

## Validation

- `PYTHONPATH=src python3 -m unittest discover -s tests -q`

## Notes

This intentionally avoids live secrets, committed key material, external keyservers, and public identity claims. It is a local tamper-detection prototype built on synthetic/local test key material only.
