### PR TITLE
[codex] Prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.3.0 - 2026-06-05
+
+- Add `evidence sign` and `evidence verify-signature` for local `hmac-sha256` evidence-bundle sidecars.
+- Document signed-bundle boundaries: local tamper detection only, unsigned bundles remain supported, and signatures do not prove command execution or artifact semantics.
+- Add regression coverage for successful signature verification and payload-mismatch failures.
+
 ## 0.2.0 - 2026-06-02
 
 - Add JUnit XML output for `verify sandbox-run` CI report consumers.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The project is intentionally target-neutral. It should help maintainers in CI, s
 Until a package index release is published, install from the repository:
 
 ```bash
-pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.2.0"
+pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.3.0"
 ```
 
 For local development:
@@ -102,4 +102,4 @@ This repository is for generic reproducibility tooling. Do not add proprietary b
 
 ## Status
 
-`0.1.x` is an early release series. The CLI and schema are intentionally small and conservative.
+`0.3.x` is an early maintainer-tooling release series. The CLI and schema stay intentionally small, conservative, and synthetic-example-only.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Recently completed
 
-These are implemented on `main` after `v0.2.0` and are candidates for the next release:
+These are available in `v0.3.0`:
 
 - Markdown output for `manifest diff` reports.
 - Include/exclude filters for large artifact-tree manifests.
@@ -14,9 +14,9 @@ These are implemented on `main` after `v0.2.0` and are candidates for the next r
 ## Near-term polish
 
 - Keep examples synthetic-only.
-- Improve README, tutorials, and cookbook examples as new workflows land.
-- Prepare compact release notes for the next release.
-- Expand CI cookbook coverage for schema validation and filtered manifest workflows.
+- Add a signature sidecar JSON Schema for the current prototype.
+- Improve `verify-signature` error output and reviewer-facing UX.
+- Keep release/install smoke checklists current as source installs evolve.
 
 ## Later ideas
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -63,3 +63,21 @@ repro-evidence evidence validate examples/evidence-bundle.yaml
 ```
 
 Evidence bundles prove byte identity for listed artifacts. They do not prove semantic correctness by themselves.
+
+## 6. Optionally sign the evidence bundle sidecar
+
+For local tamper detection, create synthetic local key material outside git, sign the exact evidence-bundle bytes, and verify the sidecar:
+
+```bash
+printf 'synthetic local test key only\n' > local-test.key
+repro-evidence evidence sign examples/evidence-bundle.yaml \
+  --key local-test.key \
+  --key-hint local-test \
+  -o evidence-bundle.yaml.sig.json
+repro-evidence evidence verify-signature examples/evidence-bundle.yaml \
+  --signature evidence-bundle.yaml.sig.json \
+  --key local-test.key
+```
+
+If the bundle file changes after signing, `verify-signature` exits with status `1` and reports a payload or signature mismatch. This proves local byte-level tamper detection only; it does not prove command execution, artifact semantics, signer identity, or trust-chain validity.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repro-evidence-kit"
-version = "0.2.0"
+version = "0.3.0"
 description = "Reproducible artifact manifests, sandbox-output verification, and evidence-bundle validation."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/repro_evidence_kit/__init__.py
+++ b/src/repro_evidence_kit/__init__.py
@@ -1,3 +1,3 @@
 """Reproducible artifact evidence toolkit."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -24,7 +24,7 @@ def _csv_list(values: list[str] | None) -> list[str]:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="repro-evidence", description="Reproducible artifact manifest and evidence-bundle tools.")
-    parser.add_argument("--version", action="version", version="repro-evidence 0.2.0")
+    parser.add_argument("--version", action="version", version="repro-evidence 0.3.0")
     sub = parser.add_subparsers(dest="command", required=True)
 
     manifest = sub.add_parser("manifest", help="Create or compare file manifests")


### PR DESCRIPTION
## Summary\n\n- bump package, module, and CLI versions to 0.3.0\n- add v0.3.0 changelog notes for the signed bundle sidecar prototype\n- update install docs, roadmap, README status, and tutorial signed-sidecar walkthrough\n\n## Validation\n\n- `uv run pytest -q`\n- `uv run --extra schema pytest -q`\n- `PYTHONPATH=src python3 -m repro_evidence_kit.cli --version`\n\n## Boundary\n\nSigned bundle docs remain scoped to local tamper detection with synthetic/local key material only; no live secrets, keyserver requirement, semantic-correctness claim, or signer-identity trust claim is added.\n