### PR TITLE
[codex] Expand evidence kit backlog features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - run: python -m unittest discover -s tests
       - run: python -m repro_evidence_kit evidence validate examples/evidence-bundle.yaml
       - run: python -m repro_evidence_kit manifest create examples/dummy-binary -o /tmp/repro-manifest.json
+      - run: python scripts/smoke_examples.py
       - name: Leakage audit
         run: |
           ! grep -RInE 'PRO7|조조전|ekd5|EEX|S_44|R_44|Phase4|Frida|xdbg|Cao Cao|save editor|game mod|/mnt/c/Users/xodnr/Desktop/new|_modding_tools' . --exclude-dir=.git --exclude=ci.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Add signature sidecar JSON Schema validation and packaged-schema regression coverage.
+- Improve `evidence verify-signature` with text output, structured error details, and optional sidecar schema checks.
+- Add `evidence sign --dry-run` for non-writing sidecar previews.
+- Add sandbox required-change checks, SARIF output, and JUnit output for evidence validation.
+- Add synthetic signed-bundle examples, use-case docs, release checklist, example smoke script, and release/install smoke script.
+
 ## 0.3.0 - 2026-06-05
 
 - Add `evidence sign` and `evidence verify-signature` for local `hmac-sha256` evidence-bundle sidecars.

--- a/README.md
+++ b/README.md
@@ -103,10 +103,13 @@ The command exits `0` when all changes are allowed and `1` when unexpected chang
 ## Documentation
 
 - [CLI reference](docs/cli.md)
+- [CLI exit codes](docs/cli-exit-codes.md)
 - [Tutorial](docs/tutorial.md)
 - [Evidence bundle format](docs/evidence-bundle-format.md)
+- [Use cases](docs/use-cases.md)
 - [Signed evidence bundles design note](docs/signed-bundles.md)
 - [Maintainer workflow](docs/maintainer-workflow.md)
+- [Release checklist](docs/release-checklist.md)
 - [GitHub Actions cookbook](docs/github-actions.md) — CI recipes for validation, manifests, sandbox checks, and schema-backed filtered workflows.
 - [Design principles](docs/design-principles.md)
 - [Roadmap](ROADMAP.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,6 @@ These are staged for the next release branch:
 ## Near-term polish
 
 - Keep examples synthetic-only.
-- Keep examples synthetic-only.
 - Expand CI recipes for signed-bundle verification and example smoke checks.
 - Add SARIF or additional JUnit adapters only after the JSON/text contracts stay stable.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,12 +11,21 @@ These are available in `v0.3.0`:
 - GitHub Actions cookbook and CI leakage audit.
 - Minimal signed evidence bundle sidecar prototype.
 
+These are staged for the next release branch:
+
+- Signature sidecar JSON Schema and packaged schema regression tests.
+- Reviewer-friendly `verify-signature --format text` output and structured JSON error details.
+- `evidence sign --dry-run` for non-writing sidecar preview.
+- Synthetic signed-bundle example, release checklist, use-cases page, and example smoke script.
+- Sandbox SARIF output, required-change checks, and evidence-validation JUnit output.
+- Fresh-environment release/install smoke script for tagged source references.
+
 ## Near-term polish
 
 - Keep examples synthetic-only.
-- Add a signature sidecar JSON Schema for the current prototype.
-- Improve `verify-signature` error output and reviewer-facing UX.
-- Keep release/install smoke checklists current as source installs evolve.
+- Keep examples synthetic-only.
+- Expand CI recipes for signed-bundle verification and example smoke checks.
+- Add SARIF or additional JUnit adapters only after the JSON/text contracts stay stable.
 
 ## Later ideas
 

--- a/docs/cli-exit-codes.md
+++ b/docs/cli-exit-codes.md
@@ -1,0 +1,11 @@
+# CLI exit codes
+
+All commands use the same top-level exit-code contract.
+
+| Code | Meaning | Examples |
+| --- | --- | --- |
+| `0` | The command completed and the checked predicate passed. | Manifest written, manifests diffed, evidence bundle valid, signature verified. |
+| `1` | The command completed and found an expected validation or verification failure. | Invalid evidence bundle, unexpected sandbox outputs, signature mismatch, unsupported signature sidecar metadata. |
+| `2` | The command could not complete because of an input, parsing, filesystem, dependency, or runtime error. | Missing JSON file, malformed sidecar JSON, unreadable evidence file, schema validation without `jsonschema`. |
+
+Use `1` as a CI policy failure and `2` as an infrastructure or invocation failure.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,15 +2,7 @@
 
 ## Exit codes
 
-All commands use the same top-level exit-code contract:
-
-| Code | Meaning | Examples |
-| --- | --- | --- |
-| `0` | The command completed and the checked predicate passed. | Manifest written, manifests diffed, evidence bundle valid, sandbox output contains only allowed changes. |
-| `1` | The command completed and found an expected validation or verification failure. | Evidence bundle is structurally invalid, sandbox output contains unexpected added/changed/removed paths. |
-| `2` | The command could not complete because of an input, parsing, filesystem, or runtime error. | Missing JSON file, malformed manifest JSON, unreadable evidence file. |
-
-Use `1` as a CI policy failure and `2` as an infrastructure or invocation failure.
+See [CLI exit codes](cli-exit-codes.md) for the shared `0`/`1`/`2` contract.
 
 ## `manifest create`
 
@@ -64,11 +56,11 @@ repro-evidence verify sandbox-run before.json after.json \
   --allow-changed output.bin
 ```
 
-Comma-separated allowlists are accepted for added, changed, and removed paths.
+Comma-separated allowlists are accepted for added, changed, and removed paths. Use `--require-added`, `--require-changed`, or `--require-removed` when an expected output must appear; a missing required change returns exit code `1`.
 
 Allowlist paths use the same normalization as manifest diffs, so `reports\summary.json` and `reports/summary.json` match the same logical artifact.
 
-Use `--format junit` when a CI system or test-report action expects JUnit XML:
+Use `--format junit` when a CI system or test-report action expects JUnit XML, or `--format sarif` when a code-scanning adapter expects SARIF results:
 
 ```bash
 repro-evidence verify sandbox-run before.json after.json \
@@ -77,7 +69,7 @@ repro-evidence verify sandbox-run before.json after.json \
   -o sandbox-verification.xml
 ```
 
-The JUnit report has one testcase named `sandbox-run`. Unexpected added, changed, or removed paths are rendered as one failure. This is a CI reporting adapter for the sandbox verification predicate; it is not a full test suite and does not change the JSON output contract.
+The JUnit report has one testcase named `sandbox-run`. Unexpected added, changed, removed, or missing required paths are rendered as one failure. SARIF output uses `unexpected-sandbox-change` and `missing-required-sandbox-change` rule IDs. These are CI reporting adapters for the sandbox verification predicate; they are not full test suites and do not change the JSON output contract.
 
 ## `evidence validate`
 
@@ -98,7 +90,7 @@ repro-evidence evidence validate examples/evidence-bundle.yaml --schema
 
 Schema-backed validation uses `schemas/evidence-bundle.schema.json` and additionally enforces constraints such as SHA-256 hex format and numeric size bounds. Use `--schema-path custom.schema.json` with `--schema` to test a local schema variant.
 
-Exit code `1` means the file was read successfully but the bundle failed validation. Exit code `2` means the file could not be read, parsed, or schema validation was requested without the optional dependency.
+Use `--format junit` to write a one-testcase XML report while preserving validation exit-code behavior. Exit code `1` means the file was read successfully but the bundle failed validation. Exit code `2` means the file could not be read, parsed, or schema validation was requested without the optional dependency.
 
 
 ## `evidence sign`
@@ -112,7 +104,7 @@ repro-evidence evidence sign examples/evidence-bundle.yaml \
   -o examples/evidence-bundle.yaml.sig.json
 ```
 
-The key file is local trust material. Do not commit live secrets or real maintainer private keys. The prototype algorithm is `hmac-sha256`, intended for local tamper detection and synthetic examples.
+The key file is local trust material. Do not commit live secrets or real maintainer private keys. The prototype algorithm is `hmac-sha256`, intended for local tamper detection and synthetic examples. Use `--dry-run` to print the sidecar that would be written without creating an output file.
 
 ## `evidence verify-signature`
 
@@ -124,4 +116,8 @@ repro-evidence evidence verify-signature examples/evidence-bundle.yaml \
   --key local-test.key
 ```
 
-Exit code `0` means the sidecar signature matches. Exit code `1` means the sidecar was read but the payload hash, signature, version, or algorithm check failed. Exit code `2` means the command could not read or parse an input. A valid signature does not prove command execution, artifact semantics, or signer identity beyond the reviewer's trust in the local key.
+Use `--format text` for maintainer-friendly CI logs, or keep the default JSON for machine-readable output. JSON results include `errors` plus structured `error_details` with stable categories such as `payload_hash_mismatch`, `signature_mismatch`, `unsupported_signature_version`, `unsupported_algorithm`, `missing_signature`, and parse/read failures as exit code `2`.
+
+Use `--schema` to validate the sidecar shape against `schemas/signature-sidecar.schema.json` when the optional `jsonschema` dependency is installed.
+
+Exit code `0` means the sidecar signature matches. Exit code `1` means the sidecar was read but the payload hash, signature, version, algorithm, or optional schema check failed. Exit code `2` means the command could not read or parse an input. A valid signature does not prove command execution, artifact semantics, or signer identity beyond the reviewer's trust in the local key.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -144,6 +144,7 @@ jobs:
         run: |
           python -m repro_evidence_kit verify sandbox-run before.json after.json \
             --allow-added report.json \
+            --require-added report.json \
             --format junit \
             -o sandbox-verification.xml
       - uses: actions/upload-artifact@v4
@@ -154,3 +155,106 @@ jobs:
 ```
 
 The JUnit output keeps the same exit-code behavior as JSON: unexpected changes still return `1` and fail the job. The XML report contains one testcase and one failure when the sandbox predicate fails.
+
+## Verify a signed evidence bundle sidecar
+
+This recipe uses a synthetic key created during the job. It is for local tamper-detection plumbing only, not public signer identity.
+
+```yaml
+name: Signed evidence smoke
+
+on:
+  pull_request:
+
+jobs:
+  signed-evidence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install -e ".[schema]"
+      - run: printf 'synthetic local test key only\n' > local-test.key
+      - run: |
+          python -m repro_evidence_kit evidence sign examples/evidence-bundle.yaml \
+            --key local-test.key \
+            --key-hint local-synthetic \
+            -o evidence-bundle.yaml.sig.json
+      - run: |
+          python -m repro_evidence_kit evidence verify-signature examples/evidence-bundle.yaml \
+            --signature evidence-bundle.yaml.sig.json \
+            --key local-test.key \
+            --schema \
+            --format text
+```
+
+## Run synthetic examples as a smoke test
+
+```yaml
+name: Example smoke
+
+on:
+  pull_request:
+
+jobs:
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install -e .
+      - run: python scripts/smoke_examples.py
+```
+
+## Upload sandbox verification as SARIF
+
+Use this when a downstream code-scanning integration accepts SARIF. The SARIF report is a compact policy-failure adapter for sandbox output verification.
+
+```yaml
+name: Sandbox SARIF
+
+on:
+  pull_request:
+
+jobs:
+  sandbox-sarif:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install -e .
+      - run: mkdir -p sandbox && printf 'input\n' > sandbox/input.txt
+      - run: python -m repro_evidence_kit manifest create sandbox -o before.json
+      - run: printf '{"ok": true}\n' > sandbox/report.json
+      - run: python -m repro_evidence_kit manifest create sandbox -o after.json
+      - run: |
+          python -m repro_evidence_kit verify sandbox-run before.json after.json \
+            --allow-added report.json \
+            --require-added report.json \
+            --format sarif \
+            -o sandbox-verification.sarif
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sandbox-verification-sarif
+          path: sandbox-verification.sarif
+```
+
+## Evidence validation as JUnit XML
+
+```yaml
+- run: |
+    python -m repro_evidence_kit evidence validate examples/evidence-bundle.yaml \
+      --format junit \
+      -o evidence-validation.xml
+- uses: actions/upload-artifact@v4
+  if: always()
+  with:
+    name: evidence-validation-junit
+    path: evidence-validation.xml
+```

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,31 @@
+# Release checklist
+
+Use this checklist before tagging a release. It is maintainer guidance, not a trust guarantee.
+
+## Before tagging
+
+1. Confirm the working tree is clean except intentional release edits.
+2. Run the base tests:
+   ```bash
+   uv run pytest -q
+   ```
+3. Run schema-extra tests when schema files changed:
+   ```bash
+   uv run --extra schema pytest -q
+   ```
+4. Run the example smoke script:
+   ```bash
+   python scripts/smoke_examples.py
+   ```
+5. Review `CHANGELOG.md`, `README.md`, and `ROADMAP.md` for version wording.
+
+## After tagging
+
+1. Install from the tagged source reference in a fresh environment.
+2. Check the CLI version:
+   ```bash
+   repro-evidence --version
+   ```
+3. Run minimal evidence signing and verification with synthetic local key material.
+4. Mutate the bundle bytes and confirm verification returns exit code `1`.
+5. Do not publish live keys, private fixtures, proprietary samples, or target-specific evidence.

--- a/docs/signed-bundles.md
+++ b/docs/signed-bundles.md
@@ -53,7 +53,7 @@ evidence-bundle.yaml.sig.json
 
 A sidecar keeps signatures optional and avoids mutating the payload after signing.
 
-Candidate sidecar fields:
+Current sidecar fields, also covered by `schemas/signature-sidecar.schema.json`:
 
 ```json
 {
@@ -85,7 +85,9 @@ repro-evidence evidence verify-signature evidence-bundle.yaml \
   --key local-test.key
 ```
 
-The prototype uses a local shared key file so it can run without external services or committed secrets. It is useful for tamper detection with locally trusted key material, not for public identity or certificate-chain validation. `evidence validate` remains unchanged and unsigned bundles keep passing validation.
+The prototype uses a local shared key file so it can run without external services or committed secrets. It is useful for tamper detection with locally trusted key material, not for public identity or certificate-chain validation. `evidence validate` remains unchanged and unsigned bundles keep passing validation. Use `--format text` for reviewer-facing CI logs and `--schema` to check the sidecar structure when the optional schema extra is installed.
+
+See `examples/signed-bundle/README.md` for a minimal synthetic workflow.
 
 ## Test fixture policy
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,19 @@
+# Use cases
+
+`repro-evidence-kit` is for small, reviewable proof surfaces around generated or artifact-heavy work. All examples should stay synthetic or redistributable.
+
+## AI-generated artifacts
+
+Use manifests and evidence bundles to record which files an automation run produced, which command was intended, and which hashes reviewers can compare. This helps reviewers challenge outputs without needing private prompts, source data, or logs in the repository.
+
+## Binary-analysis or security research outputs
+
+Use sandbox verification to distinguish expected reports from unexpected files created by a tool run. This does not prove semantic correctness; it proves the observed file-change predicate against the explicit allowlist.
+
+## Release and documentation automation
+
+Use filtered manifests for generated docs, reports, or release assets. Upload the manifest or a JUnit sandbox verification report to CI so reviewers can inspect compact artifacts instead of noisy working directories.
+
+## Signed evidence bundle review
+
+Use signed sidecars when maintainers need local tamper detection for exact evidence-bundle bytes. The current `hmac-sha256` prototype is a local-key workflow only; it is not signer identity, keyserver, certificate-chain, command-execution, or artifact-semantics proof.

--- a/examples/signed-bundle/README.md
+++ b/examples/signed-bundle/README.md
@@ -1,0 +1,20 @@
+# Signed bundle example
+
+This example demonstrates local tamper detection for exact evidence-bundle bytes.
+It uses only synthetic data and writes temporary key/signature files outside git.
+
+```bash
+printf 'synthetic local test key only\n' > /tmp/repro-evidence-local.key
+repro-evidence evidence sign examples/evidence-bundle.yaml \
+  --key /tmp/repro-evidence-local.key \
+  --key-hint local-synthetic \
+  -o /tmp/evidence-bundle.yaml.sig.json
+repro-evidence evidence verify-signature examples/evidence-bundle.yaml \
+  --signature /tmp/evidence-bundle.yaml.sig.json \
+  --key /tmp/repro-evidence-local.key \
+  --format text
+```
+
+A passing signature proves only that the exact bundle bytes match the local key
+material used by the verifier. It does not prove command execution, output
+semantics, signer identity, or a public trust chain.

--- a/schemas/signature-sidecar.schema.json
+++ b/schemas/signature-sidecar.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/xodnr927-byte/repro-evidence-kit/schemas/signature-sidecar.schema.json",
+  "title": "Repro Evidence Signature Sidecar",
+  "description": "Schema for the local hmac-sha256 signature sidecar. It validates shape only; it does not prove signer identity, trust chains, command execution, or artifact semantics.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "signature_version",
+    "payload_path",
+    "payload_sha256",
+    "algorithm",
+    "key_hint",
+    "signature"
+  ],
+  "properties": {
+    "signature_version": {
+      "const": "1.0"
+    },
+    "payload_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^\\u0000]+$"
+    },
+    "payload_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "algorithm": {
+      "const": "hmac-sha256"
+    },
+    "key_hint": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Non-secret local key identifier; not a trust-chain identity."
+    },
+    "signature": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/scripts/release_install_smoke.py
+++ b/scripts/release_install_smoke.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+import venv
+from pathlib import Path
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, expect: int = 0) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True)
+    if result.returncode != expect:
+        print(f"command failed: {' '.join(cmd)}", file=sys.stderr)
+        print(f"expected exit {expect}, got {result.returncode}", file=sys.stderr)
+        print(result.stdout, file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(2)
+    return result
+
+
+def bin_path(venv_dir: Path, name: str) -> Path:
+    if sys.platform == "win32":
+        return venv_dir / "Scripts" / f"{name}.exe"
+    return venv_dir / "bin" / name
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Fresh-environment release/install smoke check.")
+    parser.add_argument("source", help="Tagged source reference, local path, or git+ URL to install")
+    args = parser.parse_args(argv)
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        env = root / "venv"
+        venv.EnvBuilder(with_pip=True).create(env)
+        python = bin_path(env, "python")
+        repro = bin_path(env, "repro-evidence")
+        run([str(python), "-m", "pip", "install", args.source])
+        run([str(repro), "--version"])
+
+        bundle = root / "evidence-bundle.yaml"
+        key = root / "local-test.key"
+        signature = root / "evidence-bundle.yaml.sig.json"
+        bundle.write_text("schema_version: '1.0'\ntitle: Synthetic\ninputs: []\ncommands: []\noutputs: []\n", encoding="utf-8")
+        key.write_text("synthetic local test key only\n", encoding="utf-8")
+        run([str(repro), "evidence", "sign", str(bundle), "--key", str(key), "--key-hint", "local-synthetic", "-o", str(signature)])
+        run([str(repro), "evidence", "verify-signature", str(bundle), "--signature", str(signature), "--key", str(key)])
+        bundle.write_text(bundle.read_text(encoding="utf-8") + "tamper: true\n", encoding="utf-8")
+        run([str(repro), "evidence", "verify-signature", str(bundle), "--signature", str(signature), "--key", str(key)], expect=1)
+
+    print("release/install smoke checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_examples.py
+++ b/scripts/smoke_examples.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON = sys.executable
+
+
+def run(args: list[str], *, expect: int = 0) -> subprocess.CompletedProcess[str]:
+    cmd = [PYTHON, "-m", "repro_evidence_kit", *args]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True, env=env)
+    if result.returncode != expect:
+        print(f"command failed: {' '.join(cmd)}", file=sys.stderr)
+        print(f"expected exit {expect}, got {result.returncode}", file=sys.stderr)
+        print(result.stdout, file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(2)
+    return result
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        before = tmp / "before.json"
+        after = tmp / "after.json"
+        diff = tmp / "diff.md"
+        verify = tmp / "verify.json"
+        key = tmp / "local-test.key"
+        signature = tmp / "evidence-bundle.yaml.sig.json"
+        sig_text = tmp / "verify-signature.txt"
+
+        run(["manifest", "create", "examples/dummy-binary", "-o", str(before)])
+        run(["manifest", "diff", str(before), str(before), "--format", "markdown", "-o", str(diff)])
+        run(["evidence", "validate", "examples/evidence-bundle.yaml"])
+
+        sandbox = tmp / "sandbox"
+        sandbox.mkdir()
+        (sandbox / "input.txt").write_text("input\n", encoding="utf-8")
+        run(["manifest", "create", str(sandbox), "-o", str(before)])
+        (sandbox / "report.json").write_text('{"ok": true}\n', encoding="utf-8")
+        run(["manifest", "create", str(sandbox), "-o", str(after)])
+        run(["verify", "sandbox-run", str(before), str(after), "--allow-added", "report.json", "-o", str(verify)])
+
+        key.write_text("synthetic local test key only\n", encoding="utf-8")
+        run(["evidence", "sign", "examples/evidence-bundle.yaml", "--key", str(key), "--key-hint", "local-synthetic", "-o", str(signature)])
+        run([
+            "evidence",
+            "verify-signature",
+            "examples/evidence-bundle.yaml",
+            "--signature",
+            str(signature),
+            "--key",
+            str(key),
+            "--format",
+            "text",
+            "-o",
+            str(sig_text),
+        ])
+        sidecar = json.loads(signature.read_text(encoding="utf-8"))
+        if sidecar["algorithm"] != "hmac-sha256":
+            raise SystemExit(2)
+
+    print("example smoke checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -131,12 +131,16 @@ def main(argv: list[str] | None = None) -> int:
                 write_json(result, args.output)
             return 0 if result["ok"] else 1
         if args.command == "evidence" and args.evidence_command == "sign":
-            sidecar = sign_bundle(args.bundle, args.key, key_hint=args.key_hint)
             if args.dry_run:
+                sidecar = sign_bundle(args.bundle, args.key, key_hint=args.key_hint)
                 write_json(sidecar, None)
                 return 0
             if args.output is None:
                 raise ValueError("evidence sign requires -o/--output unless --dry-run is used")
+            output_path = args.output.resolve()
+            if output_path in {args.bundle.resolve(), args.key.resolve()}:
+                raise ValueError("signature output must not overwrite the bundle or key file")
+            sidecar = sign_bundle(args.bundle, args.key, key_hint=args.key_hint)
             write_json(sidecar, args.output)
             return 0
         if args.command == "evidence" and args.evidence_command == "verify-signature":

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -4,10 +4,10 @@ import argparse
 import sys
 from pathlib import Path
 
-from .evidence import load_evidence, validate_evidence_bundle, validate_evidence_bundle_schema
+from .evidence import evidence_result_as_junit, load_evidence, validate_evidence_bundle, validate_evidence_bundle_schema, validate_signature_sidecar_schema
 from .manifest import create_manifest, diff_manifests, load_json, write_json, write_text
-from .signing import load_signature_sidecar, sign_bundle, verify_bundle_signature
-from .verify import sandbox_result_as_junit, verify_sandbox_output
+from .signing import load_signature_sidecar, sign_bundle, signature_verification_as_text, verify_bundle_signature
+from .verify import sandbox_result_as_junit, sandbox_result_as_sarif, verify_sandbox_output
 
 
 def _csv_set(value: str | None) -> set[str]:
@@ -50,7 +50,10 @@ def build_parser() -> argparse.ArgumentParser:
     sandbox.add_argument("--allow-added", help="Comma-separated path allowlist")
     sandbox.add_argument("--allow-changed", help="Comma-separated path allowlist")
     sandbox.add_argument("--allow-removed", help="Comma-separated path allowlist")
-    sandbox.add_argument("--format", choices=("json", "junit"), default="json")
+    sandbox.add_argument("--require-added", help="Comma-separated paths that must be added")
+    sandbox.add_argument("--require-changed", help="Comma-separated paths that must be changed")
+    sandbox.add_argument("--require-removed", help="Comma-separated paths that must be removed")
+    sandbox.add_argument("--format", choices=("json", "junit", "sarif"), default="json")
     sandbox.add_argument("-o", "--output", type=Path)
 
     evidence = sub.add_parser("evidence", help="Validate and sign evidence bundles")
@@ -59,18 +62,23 @@ def build_parser() -> argparse.ArgumentParser:
     val.add_argument("bundle", type=Path)
     val.add_argument("--schema", action="store_true", help="Validate with schemas/evidence-bundle.schema.json using the optional jsonschema dependency")
     val.add_argument("--schema-path", type=Path, help="Use a custom JSON Schema path with --schema")
+    val.add_argument("--format", choices=("json", "junit"), default="json")
     val.add_argument("-o", "--output", type=Path)
 
     sign = evidence_sub.add_parser("sign", help="Sign exact evidence bundle bytes with a local key")
     sign.add_argument("bundle", type=Path)
     sign.add_argument("--key", required=True, type=Path, help="Local synthetic or trusted HMAC key file")
     sign.add_argument("--key-hint", help="Non-secret key identifier to record in the sidecar")
-    sign.add_argument("-o", "--output", type=Path, required=True)
+    sign.add_argument("-o", "--output", type=Path)
+    sign.add_argument("--dry-run", action="store_true", help="Print the sidecar that would be written without creating an output file")
 
     verify_sig = evidence_sub.add_parser("verify-signature", help="Verify an evidence bundle signature sidecar")
     verify_sig.add_argument("bundle", type=Path)
     verify_sig.add_argument("--signature", required=True, type=Path, help="Signature sidecar JSON")
     verify_sig.add_argument("--key", required=True, type=Path, help="Local synthetic or trusted HMAC key file")
+    verify_sig.add_argument("--format", choices=("json", "text"), default="json")
+    verify_sig.add_argument("--schema", action="store_true", help="Also validate the signature sidecar shape with schemas/signature-sidecar.schema.json")
+    verify_sig.add_argument("--schema-path", type=Path, help="Use a custom JSON Schema path with --schema")
     verify_sig.add_argument("-o", "--output", type=Path)
     return parser
 
@@ -103,23 +111,45 @@ def main(argv: list[str] | None = None) -> int:
                 allow_added=_csv_set(args.allow_added),
                 allow_changed=_csv_set(args.allow_changed),
                 allow_removed=_csv_set(args.allow_removed),
+                require_added=_csv_set(args.require_added),
+                require_changed=_csv_set(args.require_changed),
+                require_removed=_csv_set(args.require_removed),
             )
             if args.format == "junit":
                 write_text(sandbox_result_as_junit(result), args.output)
+            elif args.format == "sarif":
+                write_text(sandbox_result_as_sarif(result), args.output)
             else:
                 write_json(result, args.output)
             return 0 if result["ok"] else 1
         if args.command == "evidence" and args.evidence_command == "validate":
             bundle = load_evidence(args.bundle)
             result = validate_evidence_bundle_schema(bundle, args.schema_path) if args.schema else validate_evidence_bundle(bundle)
-            write_json(result, args.output)
+            if args.format == "junit":
+                write_text(evidence_result_as_junit(result), args.output)
+            else:
+                write_json(result, args.output)
             return 0 if result["ok"] else 1
         if args.command == "evidence" and args.evidence_command == "sign":
-            write_json(sign_bundle(args.bundle, args.key, key_hint=args.key_hint), args.output)
+            sidecar = sign_bundle(args.bundle, args.key, key_hint=args.key_hint)
+            if args.dry_run:
+                write_json(sidecar, None)
+                return 0
+            if args.output is None:
+                raise ValueError("evidence sign requires -o/--output unless --dry-run is used")
+            write_json(sidecar, args.output)
             return 0
         if args.command == "evidence" and args.evidence_command == "verify-signature":
-            result = verify_bundle_signature(args.bundle, load_signature_sidecar(args.signature), args.key)
-            write_json(result, args.output)
+            sidecar = load_signature_sidecar(args.signature)
+            result = verify_bundle_signature(args.bundle, sidecar, args.key)
+            if args.schema:
+                schema_result = validate_signature_sidecar_schema(sidecar, args.schema_path)
+                result["schema"] = schema_result
+                result["ok"] = bool(result["ok"] and schema_result["ok"])
+            if args.format == "text":
+                write_text(signature_verification_as_text(result), args.output)
+            else:
+                write_json(result, args.output)
             return 0 if result["ok"] else 1
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/src/repro_evidence_kit/evidence.py
+++ b/src/repro_evidence_kit/evidence.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import xml.etree.ElementTree as ET
 from importlib import resources
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,7 @@ except Exception:  # pragma: no cover
     Draft202012Validator = None
 
 REPO_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "evidence-bundle.schema.json"
+REPO_SIGNATURE_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "signature-sidecar.schema.json"
 
 REQUIRED_TOP_LEVEL = {"schema_version", "title", "inputs", "commands", "outputs"}
 REQUIRED_ARTIFACT_FIELDS = {"path", "sha256"}
@@ -87,6 +89,27 @@ def default_schema_path() -> Path:
     return Path(str(resources.files("repro_evidence_kit.schemas") / "evidence-bundle.schema.json"))
 
 
+def default_signature_schema_path() -> Path:
+    if REPO_SIGNATURE_SCHEMA_PATH.exists():
+        return REPO_SIGNATURE_SCHEMA_PATH
+    return Path(str(resources.files("repro_evidence_kit.schemas") / "signature-sidecar.schema.json"))
+
+
+def validate_signature_sidecar_schema(data: dict[str, Any], schema_path: Path | None = None) -> dict[str, Any]:
+    if Draft202012Validator is None:
+        raise ValueError("schema validation requires the optional 'jsonschema' dependency; install repro-evidence-kit[schema]")
+    schema_file = schema_path or default_signature_schema_path()
+    schema = load_json_schema(schema_file)
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda error: list(error.path))
+    return {
+        "ok": not errors,
+        "errors": [format_schema_error(error) for error in errors],
+        "validator": "jsonschema Draft 2020-12",
+        "schema_path": str(schema_file),
+    }
+
+
 def load_json_schema(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as f:
         schema = json.load(f)
@@ -100,3 +123,21 @@ def format_schema_error(error: Any) -> str:
     if not location:
         location = "<root>"
     return f"{location}: {error.message}"
+
+
+def evidence_result_as_junit(result: dict[str, Any], *, name: str = "evidence-validate") -> str:
+    ok = bool(result.get("ok"))
+    suite = ET.Element(
+        "testsuite",
+        {
+            "name": f"repro-evidence {name}",
+            "tests": "1",
+            "failures": "0" if ok else "1",
+            "errors": "0",
+        },
+    )
+    case = ET.SubElement(suite, "testcase", {"classname": "repro_evidence_kit.evidence", "name": name})
+    if not ok:
+        failure = ET.SubElement(case, "failure", {"message": "evidence validation failed"})
+        failure.text = json.dumps(result.get("errors", []), indent=2, sort_keys=True)
+    return ET.tostring(suite, encoding="unicode") + "\n"

--- a/src/repro_evidence_kit/schemas/signature-sidecar.schema.json
+++ b/src/repro_evidence_kit/schemas/signature-sidecar.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/xodnr927-byte/repro-evidence-kit/schemas/signature-sidecar.schema.json",
+  "title": "Repro Evidence Signature Sidecar",
+  "description": "Schema for the local hmac-sha256 signature sidecar. It validates shape only; it does not prove signer identity, trust chains, command execution, or artifact semantics.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "signature_version",
+    "payload_path",
+    "payload_sha256",
+    "algorithm",
+    "key_hint",
+    "signature"
+  ],
+  "properties": {
+    "signature_version": {
+      "const": "1.0"
+    },
+    "payload_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^\\u0000]+$"
+    },
+    "payload_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "algorithm": {
+      "const": "hmac-sha256"
+    },
+    "key_hint": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Non-secret local key identifier; not a trust-chain identity."
+    },
+    "signature": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/src/repro_evidence_kit/signing.py
+++ b/src/repro_evidence_kit/signing.py
@@ -3,11 +3,24 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import re
 from pathlib import Path
 from typing import Any
 
 SIGNATURE_VERSION = "1.0"
 ALGORITHM = "hmac-sha256"
+SIGNATURE_ERROR_MESSAGES = {
+    "unsupported_signature_version": "unsupported signature_version",
+    "unsupported_algorithm": "unsupported algorithm",
+    "payload_hash_mismatch": "payload_sha256 mismatch",
+    "signature_mismatch": "signature mismatch",
+    "missing_signature": "missing signature",
+    "invalid_signature": "invalid signature",
+    "missing_payload_sha256": "missing payload_sha256",
+    "invalid_payload_sha256": "invalid payload_sha256",
+    "payload_path_mismatch": "payload_path mismatch",
+}
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
 
 
 def sha256_bytes(data: bytes) -> str:
@@ -42,30 +55,86 @@ def sign_bundle(bundle_path: Path, key_path: Path, *, key_hint: str | None = Non
     }
 
 
+def signature_error(code: str, *, field: str, expected: Any = None, actual: Any = None) -> dict[str, Any]:
+    detail = {"code": code, "field": field, "message": SIGNATURE_ERROR_MESSAGES[code]}
+    if expected is not None:
+        detail["expected"] = expected
+    if actual is not None:
+        detail["actual"] = actual
+    return detail
+
+
+def _append_error(errors: list[str], details: list[dict[str, Any]], code: str, **kwargs: Any) -> None:
+    errors.append(SIGNATURE_ERROR_MESSAGES[code])
+    details.append(signature_error(code, **kwargs))
+
+
 def verify_bundle_signature(bundle_path: Path, sidecar: dict[str, Any], key_path: Path) -> dict[str, Any]:
     errors: list[str] = []
+    details: list[dict[str, Any]] = []
     if sidecar.get("signature_version") != SIGNATURE_VERSION:
-        errors.append("unsupported signature_version")
+        _append_error(
+            errors,
+            details,
+            "unsupported_signature_version",
+            field="signature_version",
+            expected=SIGNATURE_VERSION,
+            actual=sidecar.get("signature_version"),
+        )
     if sidecar.get("algorithm") != ALGORITHM:
-        errors.append("unsupported algorithm")
+        _append_error(errors, details, "unsupported_algorithm", field="algorithm", expected=ALGORITHM, actual=sidecar.get("algorithm"))
 
     payload = bundle_path.read_bytes()
     payload_sha256 = sha256_bytes(payload)
-    if sidecar.get("payload_sha256") != payload_sha256:
-        errors.append("payload_sha256 mismatch")
+    recorded_payload_sha256 = sidecar.get("payload_sha256")
+    if not isinstance(recorded_payload_sha256, str) or not recorded_payload_sha256:
+        _append_error(errors, details, "missing_payload_sha256", field="payload_sha256", expected=payload_sha256, actual=recorded_payload_sha256)
+    elif not _HEX64.match(recorded_payload_sha256):
+        _append_error(errors, details, "invalid_payload_sha256", field="payload_sha256", expected="64 lowercase hex characters", actual=recorded_payload_sha256)
+    elif recorded_payload_sha256 != payload_sha256:
+        _append_error(errors, details, "payload_hash_mismatch", field="payload_sha256", expected=recorded_payload_sha256, actual=payload_sha256)
+
+    payload_path = sidecar.get("payload_path")
+    if isinstance(payload_path, str) and payload_path and payload_path != bundle_path.name:
+        _append_error(errors, details, "payload_path_mismatch", field="payload_path", expected=bundle_path.name, actual=payload_path)
 
     signature = sidecar.get("signature")
     if not isinstance(signature, str) or not signature:
-        errors.append("missing signature")
+        _append_error(errors, details, "missing_signature", field="signature", expected="64 lowercase hex characters", actual=signature)
+    elif not _HEX64.match(signature):
+        _append_error(errors, details, "invalid_signature", field="signature", expected="64 lowercase hex characters", actual=signature)
     else:
         expected = hmac.new(load_key(key_path), payload, hashlib.sha256).hexdigest()
         if not hmac.compare_digest(signature, expected):
-            errors.append("signature mismatch")
+            _append_error(errors, details, "signature_mismatch", field="signature", expected=expected, actual=signature)
 
     return {
         "ok": not errors,
         "errors": errors,
+        "error_details": details,
         "algorithm": sidecar.get("algorithm"),
+        "payload_path": sidecar.get("payload_path"),
         "payload_sha256": payload_sha256,
         "key_hint": sidecar.get("key_hint"),
     }
+
+
+def signature_verification_as_text(result: dict[str, Any]) -> str:
+    lines = ["signature verification: PASS" if result.get("ok") else "signature verification: FAIL"]
+    if result.get("algorithm"):
+        lines.append(f"algorithm: {result['algorithm']}")
+    if result.get("key_hint"):
+        lines.append(f"key_hint: {result['key_hint']}")
+    if result.get("payload_path"):
+        lines.append(f"payload_path: {result['payload_path']}")
+    if result.get("payload_sha256"):
+        lines.append(f"payload_sha256: {result['payload_sha256']}")
+    details = result.get("error_details") or []
+    if details:
+        lines.append("errors:")
+        for detail in details:
+            field = detail.get("field", "<unknown>")
+            code = detail.get("code", "unknown")
+            message = detail.get("message", code)
+            lines.append(f"- {code} ({field}): {message}")
+    return "\n".join(lines) + "\n"

--- a/src/repro_evidence_kit/verify.py
+++ b/src/repro_evidence_kit/verify.py
@@ -7,15 +7,31 @@ from typing import Any
 from .manifest import diff_manifests, normalize_manifest_path
 
 
-def verify_sandbox_output(before: dict[str, Any], after: dict[str, Any], *, allow_added: set[str] | None = None, allow_changed: set[str] | None = None, allow_removed: set[str] | None = None) -> dict[str, Any]:
+def verify_sandbox_output(
+    before: dict[str, Any],
+    after: dict[str, Any],
+    *,
+    allow_added: set[str] | None = None,
+    allow_changed: set[str] | None = None,
+    allow_removed: set[str] | None = None,
+    require_added: set[str] | None = None,
+    require_changed: set[str] | None = None,
+    require_removed: set[str] | None = None,
+) -> dict[str, Any]:
     allow_added = {normalize_manifest_path(path) for path in (allow_added or set())}
     allow_changed = {normalize_manifest_path(path) for path in (allow_changed or set())}
     allow_removed = {normalize_manifest_path(path) for path in (allow_removed or set())}
+    require_added = {normalize_manifest_path(path) for path in (require_added or set())}
+    require_changed = {normalize_manifest_path(path) for path in (require_changed or set())}
+    require_removed = {normalize_manifest_path(path) for path in (require_removed or set())}
     diff = diff_manifests(before, after).as_dict()
     unexpected_added = sorted(set(diff["added"]) - allow_added)
     unexpected_changed = sorted(set(diff["changed"]) - allow_changed)
     unexpected_removed = sorted(set(diff["removed"]) - allow_removed)
-    ok = not (unexpected_added or unexpected_changed or unexpected_removed)
+    missing_required_added = sorted(require_added - set(diff["added"]))
+    missing_required_changed = sorted(require_changed - set(diff["changed"]))
+    missing_required_removed = sorted(require_removed - set(diff["removed"]))
+    ok = not (unexpected_added or unexpected_changed or unexpected_removed or missing_required_added or missing_required_changed or missing_required_removed)
     return {
         "ok": ok,
         "diff_summary": diff["summary"],
@@ -28,6 +44,16 @@ def verify_sandbox_output(before: dict[str, Any], after: dict[str, Any], *, allo
             "added": sorted(allow_added),
             "changed": sorted(allow_changed),
             "removed": sorted(allow_removed),
+        },
+        "required": {
+            "added": sorted(require_added),
+            "changed": sorted(require_changed),
+            "removed": sorted(require_removed),
+        },
+        "missing_required": {
+            "added": missing_required_added,
+            "changed": missing_required_changed,
+            "removed": missing_required_removed,
         },
     }
 
@@ -46,6 +72,57 @@ def sandbox_result_as_junit(result: dict[str, Any]) -> str:
     )
     case = ET.SubElement(suite, "testcase", {"classname": "repro_evidence_kit.verify", "name": "sandbox-run"})
     if not ok:
-        failure = ET.SubElement(case, "failure", {"message": "unexpected sandbox output changes"})
-        failure.text = json.dumps(result.get("unexpected", {}), indent=2, sort_keys=True)
+        failure = ET.SubElement(case, "failure", {"message": "sandbox output predicate failed"})
+        failure.text = json.dumps(
+            {
+                "unexpected": result.get("unexpected", {}),
+                "missing_required": result.get("missing_required", {}),
+            },
+            indent=2,
+            sort_keys=True,
+        )
     return ET.tostring(suite, encoding="unicode") + "\n"
+
+
+def sandbox_result_as_sarif(result: dict[str, Any]) -> str:
+    """Render sandbox verification failures as a minimal SARIF log."""
+    rules = [
+        {
+            "id": "unexpected-sandbox-change",
+            "name": "Unexpected sandbox output change",
+            "shortDescription": {"text": "Sandbox output changed outside the allowlist."},
+            "help": {"text": "Add intentional outputs to the allowlist or remove unexpected artifacts."},
+        },
+        {
+            "id": "missing-required-sandbox-change",
+            "name": "Missing required sandbox output change",
+            "shortDescription": {"text": "A required sandbox output change was not observed."},
+            "help": {"text": "Check the producer command or update the required output list."},
+        },
+    ]
+    results: list[dict[str, Any]] = []
+    for group, values in (result.get("unexpected") or {}).items():
+        for path in values:
+            results.append({
+                "ruleId": "unexpected-sandbox-change",
+                "level": "error",
+                "message": {"text": f"Unexpected {group} path: {path}"},
+                "locations": [{"physicalLocation": {"artifactLocation": {"uri": path}}}],
+            })
+    for group, values in (result.get("missing_required") or {}).items():
+        for path in values:
+            results.append({
+                "ruleId": "missing-required-sandbox-change",
+                "level": "error",
+                "message": {"text": f"Missing required {group} path: {path}"},
+                "locations": [{"physicalLocation": {"artifactLocation": {"uri": path}}}],
+            })
+    sarif = {
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [{
+            "tool": {"driver": {"name": "repro-evidence", "rules": rules}},
+            "results": results,
+        }],
+    }
+    return json.dumps(sarif, indent=2, sort_keys=True) + "\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -169,6 +169,124 @@ class CliTests(unittest.TestCase):
             self.assertFalse(result["ok"])
             self.assertIn("payload_sha256 mismatch", result["errors"])
 
+
+
+    def test_verify_sandbox_sarif_output_and_required_added(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            before = root / "before.json"
+            after = root / "after.json"
+            output = root / "verify.sarif"
+            before.write_text(json.dumps({"files": []}), encoding="utf-8")
+            after.write_text(json.dumps({"files": []}), encoding="utf-8")
+
+            code = main([
+                "verify",
+                "sandbox-run",
+                str(before),
+                str(after),
+                "--allow-added",
+                "report.json",
+                "--require-added",
+                "report.json",
+                "--format",
+                "sarif",
+                "-o",
+                str(output),
+            ])
+
+            self.assertEqual(code, 1)
+            data = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(data["version"], "2.1.0")
+            self.assertEqual(data["runs"][0]["results"][0]["ruleId"], "missing-required-sandbox-change")
+
+    def test_evidence_validate_junit_output_keeps_failure_exit_code(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "bad.yaml"
+            output = root / "evidence.xml"
+            bundle.write_text("title: Missing required fields\n", encoding="utf-8")
+            code = main(["evidence", "validate", str(bundle), "--format", "junit", "-o", str(output)])
+            self.assertEqual(code, 1)
+            root_xml = ET.fromstring(output.read_text(encoding="utf-8"))
+            self.assertEqual(root_xml.attrib["failures"], "1")
+            self.assertIn("inputs", root_xml.findtext("./testcase/failure") or "")
+
+    def test_evidence_verify_signature_cli_text_output_includes_error_codes(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "bundle.yaml"
+            key = root / "local-test.key"
+            signature = root / "bundle.yaml.sig.json"
+            output = root / "verify-signature.txt"
+            bundle.write_text("title: Before\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+            self.assertEqual(main(["evidence", "sign", str(bundle), "--key", str(key), "-o", str(signature)]), 0)
+            bundle.write_text("title: After\n", encoding="utf-8")
+
+            code = main([
+                "evidence",
+                "verify-signature",
+                str(bundle),
+                "--signature",
+                str(signature),
+                "--key",
+                str(key),
+                "--format",
+                "text",
+                "-o",
+                str(output),
+            ])
+
+            self.assertEqual(code, 1)
+            text = output.read_text(encoding="utf-8")
+            self.assertIn("signature verification: FAIL", text)
+            self.assertIn("payload_hash_mismatch", text)
+            self.assertIn("signature_mismatch", text)
+
+    def test_evidence_sign_dry_run_does_not_require_output_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "bundle.yaml"
+            key = root / "local-test.key"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                code = main(["evidence", "sign", str(bundle), "--key", str(key), "--dry-run"])
+            self.assertEqual(code, 0)
+            self.assertEqual(json.loads(stdout.getvalue())["algorithm"], "hmac-sha256")
+
+    @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
+    def test_evidence_verify_signature_cli_schema_option(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "bundle.yaml"
+            key = root / "local-test.key"
+            signature = root / "bundle.yaml.sig.json"
+            output = root / "verify-signature.json"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+            self.assertEqual(main(["evidence", "sign", str(bundle), "--key", str(key), "-o", str(signature)]), 0)
+
+            code = main([
+                "evidence",
+                "verify-signature",
+                str(bundle),
+                "--signature",
+                str(signature),
+                "--key",
+                str(key),
+                "--schema",
+                "-o",
+                str(output),
+            ])
+
+            self.assertEqual(code, 0)
+            result = json.loads(output.read_text(encoding="utf-8"))
+            self.assertTrue(result["ok"])
+            self.assertTrue(result["schema"]["ok"])
+
     @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
     def test_evidence_validate_schema_cli_returns_1_for_schema_failure(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -257,6 +257,26 @@ class CliTests(unittest.TestCase):
             self.assertEqual(code, 0)
             self.assertEqual(json.loads(stdout.getvalue())["algorithm"], "hmac-sha256")
 
+    def test_evidence_sign_refuses_to_overwrite_inputs(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "bundle.yaml"
+            key = root / "local-test.key"
+            bundle_text = "title: Synthetic\n"
+            key_text = "synthetic test key only\n"
+            bundle.write_text(bundle_text, encoding="utf-8")
+            key.write_text(key_text, encoding="utf-8")
+
+            for output in (bundle, key):
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    code = main(["evidence", "sign", str(bundle), "--key", str(key), "-o", str(output)])
+                self.assertEqual(code, 2)
+                self.assertIn("must not overwrite", stderr.getvalue())
+
+            self.assertEqual(bundle.read_text(encoding="utf-8"), bundle_text)
+            self.assertEqual(key.read_text(encoding="utf-8"), key_text)
+
     @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
     def test_evidence_verify_signature_cli_schema_option(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -57,3 +57,38 @@ class EvidenceTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class SignatureSidecarSchemaTests(unittest.TestCase):
+    @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
+    def test_signature_sidecar_schema_valid(self):
+        from repro_evidence_kit.evidence import validate_signature_sidecar_schema
+
+        result = validate_signature_sidecar_schema({
+            "signature_version": "1.0",
+            "payload_path": "evidence-bundle.yaml",
+            "payload_sha256": "a" * 64,
+            "algorithm": "hmac-sha256",
+            "key_hint": "local-test",
+            "signature": "b" * 64,
+        })
+        self.assertTrue(result["ok"])
+
+    @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
+    def test_signature_sidecar_schema_rejects_unknown_algorithm(self):
+        from repro_evidence_kit.evidence import validate_signature_sidecar_schema
+
+        result = validate_signature_sidecar_schema({
+            "signature_version": "1.0",
+            "payload_path": "evidence-bundle.yaml",
+            "payload_sha256": "a" * 64,
+            "algorithm": "ed25519",
+            "key_hint": "local-test",
+            "signature": "b" * 64,
+        })
+        self.assertFalse(result["ok"])
+        self.assertTrue(any("algorithm" in error for error in result["errors"]))
+
+    def test_packaged_signature_schema_matches_checked_in_schema(self):
+        repo_schema = Path("schemas/signature-sidecar.schema.json").read_text(encoding="utf-8")
+        packaged_schema = Path("src/repro_evidence_kit/schemas/signature-sidecar.schema.json").read_text(encoding="utf-8")
+        self.assertEqual(packaged_schema, repo_schema)

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -59,3 +59,37 @@ class SigningTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class SignatureUxTests(unittest.TestCase):
+    def test_verify_reports_structured_error_details(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "evidence-bundle.yaml"
+            key = root / "local-test.key"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+            sidecar = sign_bundle(bundle, key)
+            sidecar["signature"] = "not-hex"
+
+            result = verify_bundle_signature(bundle, sidecar, key)
+
+        self.assertFalse(result["ok"])
+        self.assertIn("invalid signature", result["errors"])
+        self.assertEqual(result["error_details"][0]["code"], "invalid_signature")
+        self.assertEqual(result["error_details"][0]["field"], "signature")
+
+    def test_verify_reports_payload_path_mismatch(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "evidence-bundle.yaml"
+            key = root / "local-test.key"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+            sidecar = sign_bundle(bundle, key)
+            sidecar["payload_path"] = "other.yaml"
+
+            result = verify_bundle_signature(bundle, sidecar, key)
+
+        self.assertFalse(result["ok"])
+        self.assertIn("payload_path mismatch", result["errors"])
+        self.assertEqual(result["error_details"][0]["code"], "payload_path_mismatch")

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -48,3 +48,21 @@ class VerifyTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class VerifyReportingTests(unittest.TestCase):
+    def test_required_added_path_must_be_observed(self):
+        result = verify_sandbox_output({"files": []}, {"files": []}, allow_added={"report.json"}, require_added={"report.json"})
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["missing_required"]["added"], ["report.json"])
+
+    def test_sandbox_result_as_sarif_reports_unexpected_path(self):
+        from repro_evidence_kit.verify import sandbox_result_as_sarif
+        import json
+
+        result = verify_sandbox_output(
+            {"files": []},
+            {"files": [{"path": "report.json", "size": 2, "sha256": "a" * 64}]},
+        )
+        sarif = json.loads(sandbox_result_as_sarif(result))
+        self.assertEqual(sarif["version"], "2.1.0")
+        self.assertEqual(sarif["runs"][0]["results"][0]["ruleId"], "unexpected-sandbox-change")


### PR DESCRIPTION
## What changed

- Adds signature sidecar JSON Schema validation and packaged-schema regression coverage.
- Improves `evidence verify-signature` with reviewer-friendly text output, structured JSON error details, optional sidecar schema checks, and clearer mismatch categories.
- Adds `evidence sign --dry-run` for non-writing sidecar previews.
- Extends sandbox verification with required-change checks and SARIF output.
- Adds JUnit output for `evidence validate`.
- Adds synthetic signed-bundle example docs, use-case docs, release checklist, example smoke script, release/install smoke script, README/ROADMAP/CHANGELOG updates, and CI example smoke coverage.

## Boundaries

- Synthetic/local examples only.
- No live keys, committed secrets, proprietary fixtures, or target-specific samples.
- Signed sidecars remain local tamper detection for exact bundle bytes only; they do not prove command execution, artifact semantics, signer identity, or a public trust chain.

## Validation

- `uv run pytest -q` → 42 passed
- `uv run --extra schema pytest -q` → 42 passed
- `python3 scripts/smoke_examples.py` → example smoke checks passed
- `python3 scripts/release_install_smoke.py .` → release/install smoke checks passed
- `python3 scripts/release_install_smoke.py '.[schema]'` → release/install smoke checks passed
- `PYTHONPATH=src python3 -m unittest discover -s tests -q` → 42 tests OK
- `git diff --check` → clean
- leakage grep for protected/private project terms → no matches

## Related issues

Closes #22.
Closes #23.
Closes #24.
