### PR TITLE
[codex] Prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.0 - 2026-06-06
+
 - Add signature sidecar JSON Schema validation and packaged-schema regression coverage.
 - Improve `evidence verify-signature` with text output, structured error details, and optional sidecar schema checks.
 - Add `evidence sign --dry-run` for non-writing sidecar previews.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The project is intentionally target-neutral. It should help maintainers in CI, s
 Until a package index release is published, install from the repository:
 
 ```bash
-pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.3.0"
+pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.0"
 ```
 
 For local development:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Recently completed
 
-These are available in `v0.3.0`:
+These are available in `v0.4.0`:
 
 - Markdown output for `manifest diff` reports.
 - Include/exclude filters for large artifact-tree manifests.
@@ -10,8 +10,6 @@ These are available in `v0.3.0`:
 - Stable CLI exit-code documentation and regression coverage.
 - GitHub Actions cookbook and CI leakage audit.
 - Minimal signed evidence bundle sidecar prototype.
-
-These are staged for the next release branch:
 
 - Signature sidecar JSON Schema and packaged schema regression tests.
 - Reviewer-friendly `verify-signature --format text` output and structured JSON error details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repro-evidence-kit"
-version = "0.3.0"
+version = "0.4.0"
 description = "Reproducible artifact manifests, sandbox-output verification, and evidence-bundle validation."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/repro_evidence_kit/__init__.py
+++ b/src/repro_evidence_kit/__init__.py
@@ -1,3 +1,3 @@
 """Reproducible artifact evidence toolkit."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -24,7 +24,7 @@ def _csv_list(values: list[str] | None) -> list[str]:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="repro-evidence", description="Reproducible artifact manifest and evidence-bundle tools.")
-    parser.add_argument("--version", action="version", version="repro-evidence 0.3.0")
+    parser.add_argument("--version", action="version", version="repro-evidence 0.4.0")
     sub = parser.add_subparsers(dest="command", required=True)
 
     manifest = sub.add_parser("manifest", help="Create or compare file manifests")


### PR DESCRIPTION
## Summary

- bump package, module, and CLI versions to 0.4.0
- publish the merged signature-schema, verification UX, dry-run, CI adapter, and smoke-check work in the changelog
- update the tagged install example and roadmap release status

## Validation

- `uv run pytest -q` (43 passed)
- `uv run --extra schema pytest -q` (43 passed)
- `PYTHONPATH=src python3 -m repro_evidence_kit.cli --version`
- `python3 scripts/smoke_examples.py`
- `python3 scripts/release_install_smoke.py .`

## Boundary

Signed sidecars remain a local HMAC tamper-detection workflow. This release does not claim signer identity, public trust chains, command execution, or artifact semantic correctness.
