### PR TITLE
[codex] Update README status for v0.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ This repository is for generic reproducibility tooling. Do not add proprietary b
 
 ## Status
 
-`0.3.x` is an early maintainer-tooling release series. The CLI and schema stay intentionally small, conservative, and synthetic-example-only.
+`0.4.x` is an early maintainer-tooling release series. The CLI and schema stay intentionally small, conservative, and synthetic-example-only.


### PR DESCRIPTION
## Summary

- update the README Status section from the stale `0.3.x` series to the current `0.4.x` release series

## Validation

- confirmed the repository contains no remaining `0.3.x` status references outside excluded local environment metadata
- `git diff --check`
