### PR TITLE
[codex] Fix pre-PyPI schema install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ repro-evidence manifest create artifacts --include reports --exclude "*.tmp" -o 
 For stricter evidence-bundle checks, install the optional schema extra and validate against the checked-in JSON Schema:
 
 ```bash
-pip install "repro-evidence-kit[schema]"
+pip install "repro-evidence-kit[schema] @ git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.0"
 repro-evidence evidence validate examples/evidence-bundle.yaml --schema
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,7 +84,7 @@ The default validator is lightweight and has no dependency beyond the base packa
 For stricter JSON Schema validation, install the optional schema extra and pass `--schema`:
 
 ```bash
-pip install "repro-evidence-kit[schema]"
+pip install "repro-evidence-kit[schema] @ git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.0"
 repro-evidence evidence validate examples/evidence-bundle.yaml --schema
 ```
 


### PR DESCRIPTION
## Summary

- replace the unavailable PyPI-style schema-extra install command in README and CLI docs
- pin the documented optional-extra install to the published `v0.4.0` Git tag

## Validation

- confirmed PyPI currently has no `repro-evidence-kit` distribution
- installed the exact documented direct reference in a fresh virtual environment
- confirmed `repro-evidence 0.4.0` and the `jsonschema` extra are installed
- `git diff --check`
