### PR TITLE
[codex] Add Python CI version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,18 @@ on:
 
 jobs:
   test:
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      - run: python -m pip install -e ".[schema]"
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install ".[schema]"
       - run: python -m unittest discover -s tests
       - run: python -m repro_evidence_kit evidence validate examples/evidence-bundle.yaml
       - run: python -m repro_evidence_kit manifest create examples/dummy-binary -o /tmp/repro-manifest.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a Python 3.10, 3.11, and 3.12 CI matrix using non-editable package installs.
+
 ## 0.4.0 - 2026-06-06
 
 - Add signature sidecar JSON Schema validation and packaged-schema regression coverage.

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -23,7 +23,9 @@ python -m repro_evidence_kit evidence validate examples/evidence-bundle.yaml
 python -m repro_evidence_kit manifest create examples/dummy-binary -o /tmp/manifest.json
 ```
 
-This repository's CI also runs a leakage audit that rejects project-specific or proprietary-sample markers.
+This repository's CI runs these checks after a non-editable package install on
+Python 3.10, 3.11, and 3.12. It also runs a leakage audit that rejects
+project-specific or proprietary-sample markers.
 
 For copyable GitHub Actions snippets, see the [GitHub Actions cookbook](github-actions.md).
 


### PR DESCRIPTION
## Summary

- run CI across Python 3.10, 3.11, and 3.12
- switch CI from editable install to a normal `.[schema]` package install
- document the maintained Python-version matrix and changelog entry

Closes #30

## Validation

- `uv run pytest -q` -> 43 passed
- `uv run --extra schema pytest -q` -> 43 passed
- `python3 scripts/smoke_examples.py` -> passed
- `PYTHONPATH=src python3 -m unittest discover -s tests -q` -> OK, 43 tests
- `python3 scripts/release_install_smoke.py .` -> passed
- `python3 scripts/release_install_smoke.py '.[schema]'` -> passed
- `git diff --check` -> clean
- leakage grep with `.git`, `.venv`, `.pytest_cache`, `ci.yml`, and bytecode excluded -> no tracked-source matches

## Boundaries

- Synthetic examples only.
- No signed-bundle trust-model expansion.
- No proprietary samples or project-specific artifacts.
