### PR TITLE
[codex] Prepare PyPI trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,15 @@ jobs:
       - name: Leakage audit
         run: |
           ! grep -RInE 'PRO7|조조전|ekd5|EEX|S_44|R_44|Phase4|Frida|xdbg|Cao Cao|save editor|game mod|/mnt/c/Users/xodnr/Desktop/new|_modding_tools' . --exclude-dir=.git --exclude=ci.yml
+
+  package:
+    name: Build package distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install build twine
+      - run: python -m build
+      - run: python scripts/check_dist.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build release distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Confirm tag matches package version
+        run: |
+          package_version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          test "$GITHUB_REF_NAME" = "v$package_version"
+      - run: python -m pip install build twine
+      - run: python -m build
+      - run: python scripts/check_dist.py
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish release to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/repro-evidence-kit
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add a Python 3.10, 3.11, and 3.12 CI matrix using non-editable package installs.
+- Add checked wheel/sdist builds and a release-triggered PyPI Trusted Publishing workflow.
 
 ## 0.4.0 - 2026-06-06
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The command exits `0` when all changes are allowed and `1` when unexpected chang
 - [Signed evidence bundles design note](docs/signed-bundles.md)
 - [Maintainer workflow](docs/maintainer-workflow.md)
 - [Release checklist](docs/release-checklist.md)
+- [PyPI publishing](docs/publishing.md)
 - [GitHub Actions cookbook](docs/github-actions.md) — CI recipes for validation, manifests, sandbox checks, and schema-backed filtered workflows.
 - [Design principles](docs/design-principles.md)
 - [Roadmap](ROADMAP.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,7 @@ These are available in `v0.4.0`:
 
 - Keep examples synthetic-only.
 - Expand CI recipes for signed-bundle verification and example smoke checks.
+- Complete the first PyPI release after Trusted Publisher configuration.
 - Add SARIF or additional JUnit adapters only after the JSON/text contracts stay stable.
 
 ## Later ideas

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,42 @@
+# Publishing to PyPI
+
+This repository is prepared for tokenless PyPI publishing with GitHub Actions
+Trusted Publishing. Publishing is release-triggered; pull requests and ordinary
+branch pushes cannot upload distributions.
+
+## One-time maintainer setup
+
+Before the first PyPI release:
+
+1. Sign in to PyPI and create a pending Trusted Publisher for the project
+   `repro-evidence-kit`.
+2. Configure the GitHub publisher with:
+   - owner: `xodnr927-byte`
+   - repository: `repro-evidence-kit`
+   - workflow: `publish.yml`
+   - environment: `pypi`
+3. Create a GitHub environment named `pypi`. Add required reviewers if desired.
+4. Do not create a `PYPI_TOKEN` secret. The publish job requests a short-lived
+   OIDC credential with job-scoped `id-token: write` permission.
+
+The PyPI publisher configuration must exactly match the workflow filename and
+environment name.
+
+## Release flow
+
+1. Update the version and changelog through a reviewed pull request.
+2. Run the release checklist.
+3. Tag the exact release commit as `v<project-version>`.
+4. Publish the matching GitHub release.
+5. The `Publish to PyPI` workflow:
+   - confirms the tag matches `pyproject.toml`,
+   - builds one wheel and one source distribution,
+   - runs `twine check`,
+   - smoke-installs and exercises both distributions,
+   - passes only the checked distributions to the OIDC-enabled publish job.
+6. Confirm the project and files appear on PyPI before changing README install
+   instructions from tagged-source installation to package-index installation.
+
+The workflow does not prove package semantics beyond its tests and smoke checks.
+Trusted Publishing identifies the authorized release workflow; it does not make
+the package or its outputs inherently trustworthy.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -17,7 +17,14 @@ Use this checklist before tagging a release. It is maintainer guidance, not a tr
    ```bash
    python scripts/smoke_examples.py
    ```
-5. Review `CHANGELOG.md`, `README.md`, and `ROADMAP.md` for version wording.
+5. Build and check the wheel and source distribution:
+   ```bash
+   python -m pip install build twine
+   python -m build
+   python scripts/check_dist.py
+   ```
+6. Review `CHANGELOG.md`, `README.md`, and `ROADMAP.md` for version wording.
+7. Confirm the release tag will be exactly `v<project-version>`.
 
 ## After tagging
 
@@ -29,3 +36,6 @@ Use this checklist before tagging a release. It is maintainer guidance, not a tr
 3. Run minimal evidence signing and verification with synthetic local key material.
 4. Mutate the bundle bytes and confirm verification returns exit code `1`.
 5. Do not publish live keys, private fixtures, proprietary samples, or target-specific evidence.
+
+For the one-time Trusted Publisher setup and automated release flow, see
+[Publishing to PyPI](publishing.md).

--- a/scripts/check_dist.py
+++ b/scripts/check_dist.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(cmd: list[str]) -> None:
+    result = subprocess.run(cmd, text=True)
+    if result.returncode:
+        raise SystemExit(result.returncode)
+
+
+def one_artifact(dist: Path, pattern: str) -> Path:
+    matches = sorted(dist.glob(pattern))
+    if len(matches) != 1:
+        print(f"expected exactly one {pattern} artifact, found {len(matches)}", file=sys.stderr)
+        raise SystemExit(2)
+    return matches[0]
+
+
+def main() -> int:
+    dist = Path("dist")
+    wheel = one_artifact(dist, "*.whl")
+    sdist = one_artifact(dist, "*.tar.gz")
+
+    run([sys.executable, "-m", "twine", "check", str(wheel), str(sdist)])
+    for artifact in (wheel, sdist):
+        run([sys.executable, "scripts/release_install_smoke.py", str(artifact.resolve())])
+
+    print("distribution checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a release-triggered PyPI Trusted Publishing workflow with separate build and publish jobs
- validate wheel and sdist metadata, then fresh-install and exercise both artifacts before upload
- add the same package-distribution check to regular CI
- document the one-time pending publisher/GitHub environment setup and preserve source-install README wording until the first real PyPI release

Closes #32

## Why

The project declares package metadata and GitHub releases but is not yet registered on PyPI. This prepares a tokenless, reviewable release path without adding a long-lived `PYPI_TOKEN` or claiming that a package-index release already exists.

## Validation

- `uv run pytest -q` -> 43 passed
- `uv run --extra schema pytest -q` -> 43 passed
- `python3 scripts/smoke_examples.py` -> passed
- `PYTHONPATH=src python3 -m unittest discover -s tests -q` -> OK, 43 tests
- `uv run --with build --with twine python -m build` -> wheel and sdist built
- `uv run --with twine python scripts/check_dist.py` -> `twine check` and wheel/sdist fresh-install smoke passed
- wheel contents inspected -> packaged schemas present
- workflow YAML parsed successfully
- `git diff --check` -> clean
- tracked-source leakage grep -> no matches

## Boundaries

- No PyPI API token or live credential is added.
- No package upload occurs from this pull request.
- The publish workflow requires an exact `v<project-version>` release tag and the `pypi` GitHub environment.
- README keeps tagged-source installation until a real PyPI release is confirmed.
