### PR TITLE
[codex] Prepare v0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.1 - 2026-06-07
+
 - Add a Python 3.10, 3.11, and 3.12 CI matrix using non-editable package installs.
 - Add checked wheel/sdist builds and a release-triggered PyPI Trusted Publishing workflow.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The project is intentionally target-neutral. It should help maintainers in CI, s
 Until a package index release is published, install from the repository:
 
 ```bash
-pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.0"
+pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.1"
 ```
 
 For local development:
@@ -79,7 +79,7 @@ repro-evidence manifest create artifacts --include reports --exclude "*.tmp" -o 
 For stricter evidence-bundle checks, install the optional schema extra and validate against the checked-in JSON Schema:
 
 ```bash
-pip install "repro-evidence-kit[schema] @ git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.0"
+pip install "repro-evidence-kit[schema] @ git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.1"
 repro-evidence evidence validate examples/evidence-bundle.yaml --schema
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,7 +84,7 @@ The default validator is lightweight and has no dependency beyond the base packa
 For stricter JSON Schema validation, install the optional schema extra and pass `--schema`:
 
 ```bash
-pip install "repro-evidence-kit[schema] @ git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.0"
+pip install "repro-evidence-kit[schema] @ git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.1"
 repro-evidence evidence validate examples/evidence-bundle.yaml --schema
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repro-evidence-kit"
-version = "0.4.0"
+version = "0.4.1"
 description = "Reproducible artifact manifests, sandbox-output verification, and evidence-bundle validation."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/repro_evidence_kit/__init__.py
+++ b/src/repro_evidence_kit/__init__.py
@@ -1,3 +1,3 @@
 """Reproducible artifact evidence toolkit."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -24,7 +24,7 @@ def _csv_list(values: list[str] | None) -> list[str]:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="repro-evidence", description="Reproducible artifact manifest and evidence-bundle tools.")
-    parser.add_argument("--version", action="version", version="repro-evidence 0.4.0")
+    parser.add_argument("--version", action="version", version="repro-evidence 0.4.1")
     sub = parser.add_subparsers(dest="command", required=True)
 
     manifest = sub.add_parser("manifest", help="Create or compare file manifests")


### PR DESCRIPTION
## Summary

- bump the package, module, and CLI versions to `0.4.1`
- promote the Python-version matrix and Trusted Publishing preparation into the `0.4.1` changelog
- update tagged-source install examples to `v0.4.1` until the first PyPI upload is confirmed

## Validation

- `uv run pytest -q` -> 43 passed
- `uv run --extra schema pytest -q` -> 43 passed
- `python3 scripts/smoke_examples.py` -> passed
- `uv run --with build --with twine python -m build` -> `0.4.1` wheel and sdist built
- `uv run --with twine python scripts/check_dist.py` -> metadata and both fresh-install smokes passed
- `PYTHONPATH=src python3 -m unittest discover -s tests -q` -> OK, 43 tests
- version consistency check -> package, module, CLI, changelog, README, and CLI docs agree on `0.4.1`
- `git diff --check` -> clean

## Release boundary

After merge, tag the exact merge commit as `v0.4.1` and publish the GitHub release. The existing `Publish to PyPI` workflow will then build, check, and upload through the configured pending Trusted Publisher and `pypi` environment.
