### PR TITLE
[codex] Document first PyPI release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update installation documentation after the first verified PyPI publication.
+
 ## 0.4.1 - 2026-06-07
 
 - Add a Python 3.10, 3.11, and 3.12 CI matrix using non-editable package installs.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/xodnr927-byte/repro-evidence-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/xodnr927-byte/repro-evidence-kit/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/xodnr927-byte/repro-evidence-kit)](https://github.com/xodnr927-byte/repro-evidence-kit/releases)
+[![PyPI](https://img.shields.io/pypi/v/repro-evidence-kit)](https://pypi.org/project/repro-evidence-kit/)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 [![License](https://img.shields.io/github/license/xodnr927-byte/repro-evidence-kit)](LICENSE)
 
@@ -48,10 +49,10 @@ The project is intentionally target-neutral. It should help maintainers in CI, s
 
 ## Install
 
-Until a package index release is published, install from the repository:
+Install the latest release from PyPI:
 
 ```bash
-pip install "git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.1"
+pip install repro-evidence-kit
 ```
 
 For local development:
@@ -79,7 +80,7 @@ repro-evidence manifest create artifacts --include reports --exclude "*.tmp" -o 
 For stricter evidence-bundle checks, install the optional schema extra and validate against the checked-in JSON Schema:
 
 ```bash
-pip install "repro-evidence-kit[schema] @ git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.1"
+pip install "repro-evidence-kit[schema]"
 repro-evidence evidence validate examples/evidence-bundle.yaml --schema
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,6 @@ These are available in `v0.4.0`:
 
 - Keep examples synthetic-only.
 - Expand CI recipes for signed-bundle verification and example smoke checks.
-- Complete the first PyPI release after Trusted Publisher configuration.
 - Add SARIF or additional JUnit adapters only after the JSON/text contracts stay stable.
 
 ## Later ideas

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,7 +84,7 @@ The default validator is lightweight and has no dependency beyond the base packa
 For stricter JSON Schema validation, install the optional schema extra and pass `--schema`:
 
 ```bash
-pip install "repro-evidence-kit[schema] @ git+https://github.com/xodnr927-byte/repro-evidence-kit.git@v0.4.1"
+pip install "repro-evidence-kit[schema]"
 repro-evidence evidence validate examples/evidence-bundle.yaml --schema
 ```
 


### PR DESCRIPTION
## Summary

- switch installation examples from tagged Git source to PyPI
- add a PyPI version badge
- remove the completed first-publication item from the near-term roadmap
- record the post-release documentation update

## Confirmed publication

- PyPI project: https://pypi.org/project/repro-evidence-kit/0.4.1/
- `pip install repro-evidence-kit==0.4.1` -> installed from PyPI
- installed CLI -> `repro-evidence 0.4.1`
- packaged evidence and signature schemas -> present
- `pip install "repro-evidence-kit[schema]==0.4.1"` plus schema validation -> passed

## Validation

- `uv run pytest -q` -> 43 passed
- `uv run --extra schema pytest -q` -> 43 passed
- `python3 scripts/smoke_examples.py` -> passed
- `git diff --check` -> clean
