### PR TITLE
[codex] Update Actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install ".[schema]"
@@ -30,8 +30,8 @@ jobs:
     name: Build package distributions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - run: python -m pip install build twine

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
     name: Build release distributions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Confirm tag matches package version
@@ -23,7 +23,7 @@ jobs:
       - run: python -m pip install build twine
       - run: python -m build
       - run: python scripts/check_dist.py
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -39,7 +39,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
## Summary

Update only the GitHub-maintained actions that emitted the Node.js 20 deprecation warning:

- `actions/checkout`: `v4` -> `v6`
- `actions/setup-python`: `v5` -> `v6`
- `actions/upload-artifact`: `v4` -> `v7`
- `actions/download-artifact`: `v4` -> `v8`

Each selected major declares `using: node24` in its official `action.yml`.

## Scope boundary

- No trigger, permission, environment, job, step, input, release, or PyPI publishing behavior changed.
- `pypa/gh-action-pypi-publish@release/v1` was not named in the warning and remains unchanged.

## Warning evidence

The `v0.4.1` publish run reported:

- build job: `actions/checkout@v4`, `actions/setup-python@v5`, and `actions/upload-artifact@v4`
- publish job: `actions/download-artifact@v4`

## Validation

- workflow YAML parsed successfully
- `git diff --check` -> clean
- `uv run pytest -q` -> 43 passed
- `uv run --extra schema pytest -q` -> 43 passed
- `python3 scripts/smoke_examples.py` -> passed
- wheel/sdist build, `twine check`, and both fresh-install smokes -> passed
