### PR TITLE
[docs] Align roadmap and maintainer workflow with v0.4.1 publishing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,17 @@
 
 ## Recently completed
 
-These are available in `v0.4.0`:
+### v0.4.1
+
+- PyPI publication completed.
+- Trusted Publishing/OIDC release flow completed.
+- Package-index installation documentation completed.
+- Wheel/sdist build and check completed.
+- Schema extra and package-data verification completed.
+- Fresh-install smoke validation completed.
+- Node 24 GitHub Actions hygiene completed via PR #36.
+
+### v0.4.0
 
 - Markdown output for `manifest diff` reports.
 - Include/exclude filters for large artifact-tree manifests.
@@ -10,7 +20,6 @@ These are available in `v0.4.0`:
 - Stable CLI exit-code documentation and regression coverage.
 - GitHub Actions cookbook and CI leakage audit.
 - Minimal signed evidence bundle sidecar prototype.
-
 - Signature sidecar JSON Schema and packaged schema regression tests.
 - Reviewer-friendly `verify-signature --format text` output and structured JSON error details.
 - `evidence sign --dry-run` for non-writing sidecar preview.
@@ -22,11 +31,11 @@ These are available in `v0.4.0`:
 
 - Keep examples synthetic-only.
 - Expand CI recipes for signed-bundle verification and example smoke checks.
-- Add SARIF or additional JUnit adapters only after the JSON/text contracts stay stable.
+- Add contract and schema tests for the existing SARIF output.
 
 ## Later ideas
 
-- SARIF output for CI code-scanning integrations.
+- Optional GitHub code scanning integration for the existing SARIF output.
 - Richer signed bundle trust policies after the sidecar contract is stable.
 
 ## Non-goals

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -33,20 +33,23 @@ For copyable GitHub Actions snippets, see the [GitHub Actions cookbook](github-a
 
 Useful Codex tasks for this project include:
 
-- triaging issues into schema, CLI, docs, or test work,
-- drafting changelog entries from merged PRs,
-- reviewing whether examples are synthetic and redistributable,
-- debugging CI failures,
-- proposing narrow tests for manifest and verifier behavior.
+- issue triage,
+- documentation drafts,
+- changelog drafts,
+- CI failure diagnosis,
+- narrow test proposals.
 
-Codex should not add private datasets, proprietary samples, credentials, or target-specific reverse-engineering artifacts.
+Codex-assisted work must not introduce private datasets, proprietary samples,
+credentials, target-specific reverse-engineering artifacts, or expanded
+trust/security claims. A human maintainer must review release, publishing, and
+security-sensitive changes before merge.
 
-## Release checklist
+## Releases and publishing
 
-Before a release:
+Use the [release checklist](release-checklist.md) for the maintained pre-tag and
+post-tag validation steps instead of reproducing them here.
 
-1. Run unit tests.
-2. Validate example evidence bundles.
-3. Run the leakage audit.
-4. Confirm README examples still work.
-5. Update `CHANGELOG.md` and tag the release.
+See [Publishing to PyPI](publishing.md) for the Trusted Publishing setup and
+release flow. PyPI publishing is triggered by a release and uses tokenless
+Trusted Publishing/OIDC credentials. This authorization mechanism does not
+prove package correctness.


### PR DESCRIPTION
## Summary

- split the recently completed roadmap work into `v0.4.1` and `v0.4.0`
- record the completed PyPI, Trusted Publishing/OIDC, distribution, install-smoke, schema/package-data, and Node 24 hygiene work
- separate existing SARIF output from near-term contract/schema tests and optional later GitHub code scanning integration
- point maintainers to the canonical release checklist and publishing guide
- clarify conservative boundaries for Codex-assisted maintenance and required human review

## Scope

Documentation only:

- `ROADMAP.md`
- `docs/maintainer-workflow.md`

No source, tests, examples, schemas, package metadata, workflows, releases, tags, or publishing behavior changed.

## Validation

- confirmed only the two allowed documentation files changed
- rendered both files through GitHub's GFM Markdown API and parsed the resulting HTML
- verified local Markdown links resolve
- `git diff --check`

No package release was performed.
