### PR TITLE
[docs] Expand contributing and security policies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,110 @@
 # Contributing
 
-Contributions are welcome if they keep the project general-purpose and reviewable.
+Contributions are welcome when they keep `repro-evidence-kit` general-purpose, target-neutral, and reviewable.
 
-Do not submit proprietary binaries, copyrighted samples, private case data, credentials, or target-specific reverse-engineering artifacts. Use synthetic fixtures generated from source code whenever possible.
+This project is a maintainer-focused toolkit for small proof surfaces around generated or artifact-heavy work. It is not a place to publish private samples, proprietary targets, live investigation data, or project-specific reverse-engineering artifacts.
 
-Before opening a pull request, run:
+## Accepted contribution types
+
+Good contributions include:
+
+- documentation improvements,
+- CLI behavior fixes or narrowly scoped CLI improvements,
+- evidence-bundle or signature-sidecar validation improvements,
+- JSON Schema corrections or compatibility tests,
+- synthetic examples,
+- unit tests and regression tests,
+- CI/reporting adapter polish,
+- packaging metadata or release-documentation polish.
+
+Keep changes small and reviewable. Prefer one focused pull request over a broad mixed change.
+
+## Examples and fixtures
+
+Examples and fixtures must be synthetic or clearly redistributable.
+
+Do not add:
+
+- proprietary binaries,
+- copyrighted samples without a clear redistribution basis,
+- private datasets,
+- forensic case data,
+- client or user data,
+- credentials, tokens, keys, or secrets,
+- target-specific reverse-engineering artifacts,
+- generated logs that disclose sensitive paths or private inputs.
+
+When adding a new fixture, document what it is intended to test and why it can be safely redistributed.
+
+## Proof-boundary wording
+
+Documentation, examples, and pull requests must preserve the project's trust boundaries:
+
+- Hash manifests prove byte identity for the listed files; they do not prove semantic correctness.
+- Manifest diffs separate observed byte changes; they do not prove the changes are meaningful or safe.
+- Sandbox-output checks verify the observed file-change predicate against an allowlist; they do not prove the command was safe.
+- Evidence bundles preserve command context and artifact metadata for review; they do not prove the command actually ran unless an external reviewer validates that separately.
+- Local HMAC sidecars provide exact-bundle tamper detection only; they do not prove signer identity, public trust, command execution, or artifact semantics.
+- Trusted Publishing identifies an authorized release workflow; it does not prove package correctness.
+
+Avoid wording that expands these claims.
+
+## Tests and validation
+
+Before opening a pull request, run the relevant checks for your change.
+
+For most changes:
 
 ```bash
 python -m unittest discover -s tests
 python -m repro_evidence_kit evidence validate examples/evidence-bundle.yaml
 ```
+
+When schema behavior changes, also run schema-extra tests:
+
+```bash
+python -m pip install -e ".[schema]"
+python -m unittest discover -s tests
+python -m repro_evidence_kit evidence validate examples/evidence-bundle.yaml --schema
+```
+
+When examples or CLI examples change, run the smoke script:
+
+```bash
+python scripts/smoke_examples.py
+```
+
+When packaging metadata, package data, or release files change, build and check distributions:
+
+```bash
+python -m pip install build twine
+python -m build
+python scripts/check_dist.py
+twine check dist/*
+```
+
+## Maintainer-review requirements
+
+Human maintainer review is required before merging changes that affect:
+
+- release behavior,
+- PyPI publishing behavior,
+- package metadata,
+- security-sensitive validation behavior,
+- signature-sidecar behavior,
+- evidence-bundle schemas or trust-boundary wording,
+- examples that could be confused with private or target-specific data.
+
+Automation may help draft, test, or triage these changes, but it must not merge them without human review.
+
+## Pull request checklist
+
+A good pull request should state:
+
+- what changed,
+- why the change is needed,
+- which files are intentionally touched,
+- which validation commands were run,
+- whether the change affects trust boundaries, packaging, or release behavior.
+
+If a check was not run, say so explicitly and explain why.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,62 @@
 # Security policy
 
-Please do not attach private binaries, credentials, forensic datasets, or sensitive logs to public issues.
+`repro-evidence-kit` is security-adjacent tooling for reviewing generated artifacts and evidence metadata. Its security policy is intentionally conservative: do not publish private samples, credentials, forensic data, or sensitive logs in public project spaces.
 
-If you believe the toolkit mishandles paths, hashes, evidence bundles, or generated reports in a way that could disclose sensitive data, open a private security advisory or contact the maintainer through GitHub.
+## Supported versions
+
+The current early release line is `0.4.x`. Security fixes are handled on a best-effort basis for the current release line. Older pre-`0.4.x` releases should be treated as unsupported unless a maintainer explicitly says otherwise.
+
+## Reporting a vulnerability
+
+Use a GitHub private security advisory when possible. If that is not available, contact the maintainer through GitHub without including sensitive artifacts in the initial public message.
+
+Do not attach or paste any of the following in public issues, pull requests, comments, or logs:
+
+- private binaries,
+- credentials, tokens, API keys, signing keys, or other secrets,
+- forensic datasets,
+- sensitive logs,
+- client or user data,
+- proprietary samples,
+- target-specific reverse-engineering artifacts,
+- evidence bundles that disclose private paths, private inputs, or private outputs.
+
+Use minimized synthetic reproductions whenever possible.
+
+## Security-relevant bug classes
+
+Please report issues that could cause or hide sensitive disclosure, including:
+
+- unsafe path handling or path disclosure in manifests, diffs, evidence bundles, or reports,
+- hash or evidence-bundle mishandling that causes misleading review output,
+- generated reports that accidentally include private data,
+- signature-sidecar validation mistakes,
+- schema validation behavior that accepts unsafe or misleading metadata,
+- packaging or release workflow problems that could affect published artifacts,
+- CI/reporting adapters that misrepresent failed verification as success.
+
+## Signed sidecar limitations
+
+The signed-bundle sidecar workflow is a local HMAC tamper-detection prototype for exact evidence-bundle bytes.
+
+It does not provide:
+
+- signer identity,
+- a public trust chain,
+- certificate validation,
+- command-execution proof,
+- artifact semantic proof,
+- proof that generated outputs are safe or correct.
+
+Treat sidecars as local review aids, not public authenticity guarantees.
+
+## Handling fixes
+
+Security fixes should preserve the repository's boundaries:
+
+- examples must remain synthetic or clearly redistributable,
+- private data must not be committed as a reproduction,
+- trust and security claims must remain limited to documented behavior,
+- release and publishing changes require human maintainer review.
+
+Maintainer response is best effort. If a report requires private context to reproduce, provide the smallest safe synthetic reproduction or describe the issue without disclosing the sensitive material.


### PR DESCRIPTION
## Summary

- Expand `CONTRIBUTING.md` into a usable contributor guide for documentation, CLI, schema, tests, examples, and packaging-adjacent changes.
- Expand `SECURITY.md` with supported-version guidance, safe reporting rules, security-relevant bug classes, signed-sidecar limitations, and conservative fix boundaries.

## Scope boundary

Documentation only:

- `CONTRIBUTING.md`
- `SECURITY.md`

No source code, tests, examples, schemas, workflows, version numbers, release tags, GitHub Releases, or PyPI publishing behavior changed.

## Validation

- Limited edits to the two policy files.
- Markdown-only policy update; no package release performed.
- Requires CI/Markdown review in PR before merge.