### PR TITLE
[docs] Expand use cases, actions guide, and claim boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The command exits `0` when all changes are allowed and `1` when unexpected chang
 - [PyPI publishing](docs/publishing.md)
 - [GitHub Actions cookbook](docs/github-actions.md) — CI recipes for validation, manifests, sandbox checks, and schema-backed filtered workflows.
 - [Design principles](docs/design-principles.md)
+- [Why not just ...?](docs/why-not-just.md)
+- [Claim boundaries](docs/claim-boundaries.md)
 - [Roadmap](ROADMAP.md)
 
 ## Data policy

--- a/docs/claim-boundaries.md
+++ b/docs/claim-boundaries.md
@@ -1,0 +1,124 @@
+# Claim boundaries
+
+This document defines what `repro-evidence-kit` claims to prove and what it deliberately does not claim to prove.
+
+Use it as a consistency reference for README text, examples, pull requests, release notes, and security documentation.
+
+## Summary table
+
+| Feature | Reasonable claim | Do not claim |
+| --- | --- | --- |
+| SHA-256 manifests | Byte identity for listed files | Semantic correctness, safety, authorship, or completeness |
+| Manifest diffs | Added, removed, changed, and unchanged paths between two manifests | Whether a change is meaningful, safe, or intended |
+| Sandbox verification | Observed file changes matched explicit allow/require predicates | The command was safe, isolated, harmless, or correctly executed |
+| Evidence bundles | Review metadata for declared commands, inputs, outputs, and hashes | The command actually ran, the environment was identical, or outputs are correct |
+| JSON Schema validation | Evidence metadata has the expected structure | The metadata is truthful or the artifacts are correct |
+| JUnit output | CI-readable policy/test report format | A real unit test suite for the generated artifact semantics |
+| SARIF output | SARIF-compatible policy-failure report for sandbox verification | Full static analysis, code scanning coverage, or vulnerability proof |
+| Local HMAC sidecars | Exact-bundle tamper detection under local-key assumptions | Public signer identity, certificate validation, command execution, or public authenticity |
+| Trusted Publishing | Package was published by an authorized workflow | Package correctness, code safety, or artifact semantic validity |
+
+## Manifests
+
+A manifest records file paths, sizes, and SHA-256 digests for files selected by the command.
+
+It is valid to say that a manifest records byte identity for the listed files.
+
+It is not valid to say that a manifest proves:
+
+- the files are correct,
+- the files are safe,
+- the files are complete,
+- the files were produced by a specific command,
+- omitted files were irrelevant.
+
+## Manifest diffs
+
+A manifest diff compares two manifests and classifies paths as added, removed, changed, or unchanged.
+
+It is valid to say that the diff separates observed byte-level changes.
+
+It is not valid to say that the diff proves the change was intended, meaningful, harmless, or semantically correct.
+
+## Sandbox verification
+
+Sandbox verification checks observed file changes against explicit allow and require predicates.
+
+It is valid to say that a passing sandbox check means the observed manifest difference matched the configured predicate.
+
+It is not valid to say that a passing sandbox check proves:
+
+- the command was safe,
+- the command was sandboxed by this tool,
+- the environment was isolated,
+- no private data was touched,
+- the output content is correct.
+
+## Evidence bundles
+
+Evidence bundles preserve review metadata such as command context, declared inputs, declared outputs, and hashes.
+
+It is valid to say that they make a review surface explicit and portable.
+
+It is not valid to say that an evidence bundle proves the command actually ran. That requires independent rerun evidence, CI evidence, or other external validation.
+
+## JSON Schema validation
+
+Schema validation checks metadata shape and required fields.
+
+It is valid to say that schema validation catches malformed or structurally incomplete evidence metadata.
+
+It is not valid to say that schema validation proves the metadata is truthful.
+
+## JUnit and SARIF outputs
+
+JUnit and SARIF outputs are reporting adapters.
+
+It is valid to say that they make policy failures easier to consume in CI or downstream report tools.
+
+It is not valid to say that they turn sandbox verification into semantic test coverage, full code scanning, or vulnerability analysis.
+
+## Local HMAC sidecars
+
+Signed sidecars are local HMAC sidecars for exact evidence-bundle bytes.
+
+It is valid to say that verification detects whether the bundle bytes match the sidecar under the same local key.
+
+It is not valid to say that sidecars prove:
+
+- public signer identity,
+- public trust,
+- a certificate chain,
+- command execution,
+- artifact correctness,
+- package correctness.
+
+Do not commit real keys. Use synthetic keys only in examples and CI smoke tests.
+
+## Trusted Publishing
+
+Trusted Publishing helps publish packages without a long-lived PyPI token and ties publishing to an authorized repository workflow.
+
+It is valid to say that a package was published through the configured workflow.
+
+It is not valid to say that Trusted Publishing proves the package content is correct, safe, complete, or semantically valid.
+
+## Preferred wording
+
+Prefer wording like:
+
+- "records byte identity"
+- "classifies observed changes"
+- "checks the observed output set against an explicit allowlist"
+- "preserves review metadata"
+- "provides local exact-bundle tamper detection"
+- "uses Trusted Publishing for tokenless PyPI release workflow"
+
+Avoid wording like:
+
+- "proves correctness"
+- "proves safety"
+- "proves command execution"
+- "proves authenticity" without a local-key qualifier
+- "secure signing" without explaining the local HMAC boundary
+- "full provenance" or "supply-chain attestation"

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -2,6 +2,22 @@
 
 These snippets use synthetic paths and generic artifact names. Replace the paths with outputs from your own repository, but do not commit private source data or proprietary samples.
 
+## Choose a workflow
+
+| Need | Use | Output |
+| --- | --- | --- |
+| Validate evidence metadata | `repro-evidence evidence validate` | exit code, optional text/JUnit |
+| Validate evidence metadata against JSON Schema | `repro-evidence evidence validate --schema` | stricter validation result |
+| Create an artifact manifest | `repro-evidence manifest create` | JSON manifest |
+| Diff generated outputs | `repro-evidence manifest diff` | added/removed/changed/unchanged paths |
+| Gate sandbox outputs | `repro-evidence verify sandbox-run` | policy exit code and optional report |
+| Publish CI-readable sandbox failures | `verify sandbox-run --format junit` | JUnit XML artifact |
+| Publish SARIF-compatible sandbox failures | `verify sandbox-run --format sarif` | SARIF JSON artifact |
+| Check local tamper detection | `evidence sign` and `evidence verify-signature` | local HMAC sidecar result |
+| Smoke-test synthetic examples | `python scripts/smoke_examples.py` | example command pass/fail |
+
+Use the smallest recipe that matches the review question. These workflows provide compact review artifacts; they do not prove command safety, semantic correctness, public signer identity, or full supply-chain provenance.
+
 ## Validate evidence bundles
 
 ```yaml

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,19 +1,185 @@
 # Use cases
 
-`repro-evidence-kit` is for small, reviewable proof surfaces around generated or artifact-heavy work. All examples should stay synthetic or redistributable.
+`repro-evidence-kit` is for small, reviewable proof surfaces around generated or artifact-heavy work. All examples should stay synthetic or clearly redistributable.
 
-## AI-generated artifacts
+The common pattern is:
 
-Use manifests and evidence bundles to record which files an automation run produced, which command was intended, and which hashes reviewers can compare. This helps reviewers challenge outputs without needing private prompts, source data, or logs in the repository.
+1. create a compact artifact description,
+2. attach it to a pull request, CI run, release note, or maintainer handoff,
+3. let reviewers check what changed without publishing private inputs or noisy logs.
 
-## Binary-analysis or security research outputs
+## Generated artifact review
 
-Use sandbox verification to distinguish expected reports from unexpected files created by a tool run. This does not prove semantic correctness; it proves the observed file-change predicate against the explicit allowlist.
+### Problem
 
-## Release and documentation automation
+Generated outputs are difficult to review when the only evidence is a large log, a private input directory, or a claim that no important files changed.
 
-Use filtered manifests for generated docs, reports, or release assets. Upload the manifest or a JUnit sandbox verification report to CI so reviewers can inspect compact artifacts instead of noisy working directories.
+### When to use this
+
+Use this when a tool, script, model, build step, or automation job emits files that reviewers need to inspect indirectly.
+
+### Minimal workflow
+
+```bash
+repro-evidence manifest create artifacts -o manifest.json
+repro-evidence manifest diff before.json manifest.json
+repro-evidence evidence validate examples/evidence-bundle.yaml
+```
+
+### What reviewers can verify
+
+Reviewers can inspect file paths, SHA-256 digests, added/removed/changed status, and evidence-bundle metadata. They can also decide whether the produced files match the expected review surface.
+
+### What this does not prove
+
+This does not prove that generated artifacts are semantically correct, useful, safe, or complete. It only gives reviewers a compact, hash-backed surface to challenge.
+
+### Reviewer warnings
+
+Do not include private source data, proprietary samples, credentials, forensic case files, or large raw logs in the evidence bundle.
+
+## Artifact-heavy CI or release automation
+
+### Problem
+
+CI and release jobs often produce many files, but reviewers usually need to know whether the stable outputs changed in expected ways.
+
+### When to use this
+
+Use filtered manifests when the relevant outputs are a subset of a larger working directory. Use sandbox verification when a job should produce only an explicit set of output paths.
+
+### Minimal workflow
+
+```bash
+repro-evidence manifest create artifacts --include reports --exclude "*.tmp" -o filtered-manifest.json
+repro-evidence verify sandbox-run before.json after.json --allow-added report.json
+```
+
+### What reviewers can verify
+
+Reviewers can check that the recorded artifact tree includes only the selected outputs and that unexpected sandbox changes fail the job.
+
+### What this does not prove
+
+This does not prove that the CI command was safe. A passing sandbox check means the observed file-change predicate matched the allowlist.
+
+### Reviewer warnings
+
+Avoid broad include patterns that accidentally capture private working directories or transient cache files.
+
+## Security or binary-analysis research outputs
+
+### Problem
+
+Security and binary-analysis work can produce reports, traces, generated metadata, and intermediate files that should be reviewable without publishing private or proprietary inputs.
+
+### When to use this
+
+Use this when you can publish synthetic or redistributable outputs, but not the original target material or private runtime logs.
+
+### Minimal workflow
+
+```bash
+repro-evidence manifest create reports -o reports-manifest.json
+repro-evidence evidence validate evidence-bundle.yaml
+```
+
+### What reviewers can verify
+
+Reviewers can inspect which report files exist, which hashes are claimed, which command context was recorded, and whether the evidence-bundle metadata is structurally valid.
+
+### What this does not prove
+
+This does not prove vulnerability impact, reverse-engineering correctness, exploitability, authorship, command execution, or the semantic truth of a report.
+
+### Reviewer warnings
+
+Keep examples target-neutral. Do not add proprietary binaries, private traces, exploit material, credentials, or target-specific reverse-engineering artifacts.
 
 ## Signed evidence bundle review
 
-Use signed sidecars when maintainers need local tamper detection for exact evidence-bundle bytes. The current `hmac-sha256` prototype is a local-key workflow only; it is not signer identity, keyserver, certificate-chain, command-execution, or artifact-semantics proof.
+### Problem
+
+Maintainers may want to detect whether a reviewed evidence bundle has changed after local review.
+
+### When to use this
+
+Use signed sidecars for local exact-byte tamper detection when the same maintainers control the local key material.
+
+### Minimal workflow
+
+```bash
+printf 'synthetic local test key only\n' > local-test.key
+repro-evidence evidence sign examples/evidence-bundle.yaml --key local-test.key -o evidence-bundle.yaml.sig.json
+repro-evidence evidence verify-signature examples/evidence-bundle.yaml --signature evidence-bundle.yaml.sig.json --key local-test.key
+```
+
+### What reviewers can verify
+
+Reviewers can verify that the evidence-bundle bytes match a local HMAC sidecar created with the same local key.
+
+### What this does not prove
+
+This does not prove signer identity, public trust, certificate-chain validity, command execution, artifact semantics, or package correctness.
+
+### Reviewer warnings
+
+Do not commit real keys. Do not treat local sidecars as public authenticity guarantees.
+
+## Documentation or report generation
+
+### Problem
+
+Documentation and report-generation jobs can create noisy diffs or many intermediate files, even when reviewers only care about stable generated outputs.
+
+### When to use this
+
+Use manifests to record stable generated reports or documentation outputs. Use evidence bundles to describe the generation command and inputs at a high level.
+
+### Minimal workflow
+
+```bash
+repro-evidence manifest create generated-docs -o docs-manifest.json
+repro-evidence manifest diff previous-docs-manifest.json docs-manifest.json
+```
+
+### What reviewers can verify
+
+Reviewers can verify which generated files changed and whether the output set stayed within the expected documentation or report directory.
+
+### What this does not prove
+
+This does not prove that the prose, chart, or report content is accurate.
+
+### Reviewer warnings
+
+Avoid storing private source documents or proprietary generated reports unless they are intentionally redistributable.
+
+## Maintainer handoff and reproducibility notes
+
+### Problem
+
+A reviewer may need to understand what was generated, from which declared inputs, and which outputs should be checked, without rerunning a private or expensive process immediately.
+
+### When to use this
+
+Use evidence bundles with manifests when handing off generated artifacts between maintainers or across CI jobs.
+
+### Minimal workflow
+
+```bash
+repro-evidence manifest create outputs -o outputs-manifest.json
+repro-evidence evidence validate handoff-evidence.yaml
+```
+
+### What reviewers can verify
+
+Reviewers can inspect the declared command context, inputs, outputs, hashes, and evidence metadata.
+
+### What this does not prove
+
+This does not prove that the command was actually executed, that the environment was identical, or that a result is reproducible without independent rerun evidence.
+
+### Reviewer warnings
+
+Keep handoff metadata concise. Do not use evidence bundles as a dumping ground for private logs or internal-only notes.

--- a/docs/why-not-just.md
+++ b/docs/why-not-just.md
@@ -1,0 +1,78 @@
+# Why not just ...?
+
+`repro-evidence-kit` is intentionally small. It does not try to replace Git, CI artifacts, signed commits, SBOMs, SLSA provenance, or a full supply-chain attestation system.
+
+Its purpose is narrower: provide a low-friction review surface for generated or artifact-heavy work.
+
+## Why not just `sha256sum`?
+
+`sha256sum` is useful for one file or a simple list of files, but it does not provide a review workflow by itself.
+
+`repro-evidence-kit` adds:
+
+- deterministic directory manifests,
+- include/exclude filtering,
+- added/removed/changed/unchanged classification,
+- evidence-bundle metadata,
+- sandbox output predicates,
+- optional CI report formats.
+
+A hash still proves only byte identity. It does not prove semantic correctness.
+
+## Why not just `git diff`?
+
+`git diff` is strong for tracked source files, but generated artifacts are often untracked, too large, produced in CI, or not suitable for direct repository commits.
+
+`repro-evidence-kit` is useful when reviewers need compact metadata about generated outputs without storing private inputs, large output directories, or noisy logs in the repository.
+
+It does not replace source review. It complements source review when generated artifacts need a smaller evidence surface.
+
+## Why not just JSON Schema?
+
+JSON Schema can validate the shape of evidence metadata, but it cannot decide whether the generated output set changed in expected ways.
+
+`repro-evidence-kit` uses schema validation as one layer. It also records file hashes, compares manifests, and checks sandbox output changes against explicit allowlists.
+
+Schema validity does not prove artifact correctness or command execution.
+
+## Why not just upload GitHub Actions artifacts?
+
+Uploading artifacts stores files from a workflow, but it does not automatically explain which paths were expected, which paths changed, or whether an unexpected output should fail the job.
+
+`repro-evidence-kit` can generate compact manifests, JUnit XML, or SARIF-compatible reports that summarize the review question.
+
+GitHub artifact upload is a transport mechanism. It is not a review policy by itself.
+
+## Why not just signed commits or signed tags?
+
+Signed commits and tags can help verify who pushed or released repository history, but they do not prove that a generated evidence bundle remained unchanged after local review.
+
+Local HMAC sidecars in this project are narrower: they detect exact-byte changes to an evidence bundle when the same local key is available.
+
+They do not provide public signer identity, a certificate chain, command-execution proof, or artifact semantic proof.
+
+## Why not full SLSA or supply-chain provenance?
+
+Full provenance frameworks are valuable for mature release pipelines, but they can be heavy for small maintainer workflows, synthetic examples, and early-stage generated-artifact review.
+
+`repro-evidence-kit` deliberately stays smaller:
+
+- local CLI first,
+- target-neutral examples,
+- explicit trust boundaries,
+- compact review artifacts,
+- no claim of full supply-chain attestation.
+
+A project that needs full provenance can still use this toolkit for narrow artifact review, but should not treat it as a replacement for a complete provenance system.
+
+## Design boundary
+
+This project should remain honest about what it proves:
+
+- manifests prove byte identity for listed files,
+- diffs classify observed manifest changes,
+- sandbox checks evaluate observed file changes against explicit predicates,
+- evidence bundles preserve review metadata,
+- local HMAC sidecars detect exact-bundle tampering under local-key assumptions.
+
+It should not claim to prove semantic correctness, command safety, public signer identity, package correctness, or full reproducibility without independent rerun evidence.


### PR DESCRIPTION
## Summary

- Expand `docs/use-cases.md` into practical maintainer-oriented workflows with problem, usage, verification, limits, and warning sections.
- Add a top-level workflow selector table to `docs/github-actions.md`.
- Add `docs/why-not-just.md` to explain why this toolkit is narrower than sha256sum, git diff, JSON Schema, artifact uploads, signed commits, or full provenance systems.
- Add `docs/claim-boundaries.md` as a consistency reference for hash, manifest diff, sandbox, evidence bundle, schema, JUnit, SARIF, local HMAC sidecar, and Trusted Publishing claims.
- Link the new documents from the README.

## Scope boundary

Changed documentation only:

- `README.md`
- `docs/use-cases.md`
- `docs/github-actions.md`
- `docs/why-not-just.md`
- `docs/claim-boundaries.md`

No source code, tests, examples, schemas, workflows, version numbers, release tags, GitHub Releases, or PyPI publishing behavior changed.

## Validation

- Documentation-only change.
- New examples use synthetic paths and generic artifact names.
- No package release performed.