### PR TITLE
[tests] Add signed sidecar and SARIF contract coverage

### DIFF
--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -56,9 +56,55 @@ class SigningTests(unittest.TestCase):
         self.assertFalse(result["ok"])
         self.assertIn("unsupported algorithm", result["errors"])
 
+    def test_verify_rejects_wrong_key(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "evidence-bundle.yaml"
+            signing_key = root / "signing.key"
+            wrong_key = root / "wrong.key"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            signing_key.write_text("synthetic signing key only\n", encoding="utf-8")
+            wrong_key.write_text("different synthetic key only\n", encoding="utf-8")
 
-if __name__ == "__main__":
-    unittest.main()
+            sidecar = sign_bundle(bundle, signing_key)
+            result = verify_bundle_signature(bundle, sidecar, wrong_key)
+
+        self.assertFalse(result["ok"])
+        self.assertIn("signature mismatch", result["errors"])
+        self.assertEqual(result["error_details"][-1]["code"], "signature_mismatch")
+
+    def test_verify_rejects_missing_signature(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "evidence-bundle.yaml"
+            key = root / "local-test.key"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+            sidecar = sign_bundle(bundle, key)
+            del sidecar["signature"]
+
+            result = verify_bundle_signature(bundle, sidecar, key)
+
+        self.assertFalse(result["ok"])
+        self.assertIn("missing signature", result["errors"])
+        self.assertEqual(result["error_details"][-1]["code"], "missing_signature")
+
+    def test_verify_rejects_invalid_payload_hash_shape(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "evidence-bundle.yaml"
+            key = root / "local-test.key"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            key.write_text("synthetic test key only\n", encoding="utf-8")
+            sidecar = sign_bundle(bundle, key)
+            sidecar["payload_sha256"] = "not-a-sha256"
+
+            result = verify_bundle_signature(bundle, sidecar, key)
+
+        self.assertFalse(result["ok"])
+        self.assertIn("invalid payload_sha256", result["errors"])
+        self.assertEqual(result["error_details"][0]["code"], "invalid_payload_sha256")
+
 
 class SignatureUxTests(unittest.TestCase):
     def test_verify_reports_structured_error_details(self):
@@ -93,3 +139,7 @@ class SignatureUxTests(unittest.TestCase):
         self.assertFalse(result["ok"])
         self.assertIn("payload_path mismatch", result["errors"])
         self.assertEqual(result["error_details"][0]["code"], "payload_path_mismatch")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
 import unittest
 import xml.etree.ElementTree as ET
 
-from repro_evidence_kit.verify import sandbox_result_as_junit, verify_sandbox_output
+from repro_evidence_kit.verify import sandbox_result_as_junit, sandbox_result_as_sarif, verify_sandbox_output
 
 
 class VerifyTests(unittest.TestCase):
@@ -22,7 +23,7 @@ class VerifyTests(unittest.TestCase):
 
     def test_allowlist_normalizes_windows_style_paths(self):
         before = {"files": []}
-        after = {"files": [{"path": "reports\\summary.json", "size": 2, "sha256": "a" * 64}]}
+        after = {"files": [{"path": "reports\summary.json", "size": 2, "sha256": "a" * 64}]}
         result = verify_sandbox_output(before, after, allow_added={"reports/summary.json"})
         self.assertTrue(result["ok"])
         self.assertEqual(result["allowed"]["added"], ["reports/summary.json"])
@@ -46,23 +47,57 @@ class VerifyTests(unittest.TestCase):
         self.assertIsNone(root.find("./testcase/failure"))
 
 
-if __name__ == "__main__":
-    unittest.main()
-
 class VerifyReportingTests(unittest.TestCase):
     def test_required_added_path_must_be_observed(self):
         result = verify_sandbox_output({"files": []}, {"files": []}, allow_added={"report.json"}, require_added={"report.json"})
         self.assertFalse(result["ok"])
         self.assertEqual(result["missing_required"]["added"], ["report.json"])
 
-    def test_sandbox_result_as_sarif_reports_unexpected_path(self):
-        from repro_evidence_kit.verify import sandbox_result_as_sarif
-        import json
-
+    def test_sarif_reports_unexpected_path_contract(self):
         result = verify_sandbox_output(
             {"files": []},
             {"files": [{"path": "report.json", "size": 2, "sha256": "a" * 64}]},
         )
         sarif = json.loads(sandbox_result_as_sarif(result))
+
         self.assertEqual(sarif["version"], "2.1.0")
-        self.assertEqual(sarif["runs"][0]["results"][0]["ruleId"], "unexpected-sandbox-change")
+        self.assertEqual(sarif["$schema"], "https://json.schemastore.org/sarif-2.1.0.json")
+        run = sarif["runs"][0]
+        self.assertEqual(run["tool"]["driver"]["name"], "repro-evidence")
+        rule_ids = {rule["id"] for rule in run["tool"]["driver"]["rules"]}
+        self.assertIn("unexpected-sandbox-change", rule_ids)
+        self.assertIn("missing-required-sandbox-change", rule_ids)
+
+        self.assertEqual(len(run["results"]), 1)
+        finding = run["results"][0]
+        self.assertEqual(finding["ruleId"], "unexpected-sandbox-change")
+        self.assertEqual(finding["level"], "error")
+        self.assertEqual(finding["locations"][0]["physicalLocation"]["artifactLocation"]["uri"], "report.json")
+        self.assertIn("Unexpected added path", finding["message"]["text"])
+
+    def test_sarif_reports_missing_required_path_contract(self):
+        result = verify_sandbox_output(
+            {"files": []},
+            {"files": []},
+            allow_added={"report.json"},
+            require_added={"report.json"},
+        )
+        sarif = json.loads(sandbox_result_as_sarif(result))
+        finding = sarif["runs"][0]["results"][0]
+
+        self.assertEqual(finding["ruleId"], "missing-required-sandbox-change")
+        self.assertEqual(finding["level"], "error")
+        self.assertEqual(finding["locations"][0]["physicalLocation"]["artifactLocation"]["uri"], "report.json")
+        self.assertIn("Missing required added path", finding["message"]["text"])
+
+    def test_sarif_success_has_no_results_but_keeps_rules(self):
+        result = verify_sandbox_output({"files": []}, {"files": []})
+        sarif = json.loads(sandbox_result_as_sarif(result))
+        run = sarif["runs"][0]
+
+        self.assertEqual(run["results"], [])
+        self.assertEqual({rule["id"] for rule in run["tool"]["driver"]["rules"]}, {"unexpected-sandbox-change", "missing-required-sandbox-change"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add signed sidecar negative coverage for wrong keys, missing signatures, and invalid payload hashes.
- Keep existing exact-bundle success and changed-payload failure coverage.
- Expand SARIF contract coverage for unexpected sandbox changes, missing required changes, and success-with-no-results behavior.
- Assert stable SARIF version, schema URL, tool name, rule ids, levels, message text, and artifact URI fields.

## Scope boundary

Changed tests only:

- `tests/test_signing.py`
- `tests/test_verify.py`

No source code, examples, schemas, workflows, package metadata, version numbers, release tags, GitHub Releases, or PyPI publishing behavior changed.

## Validation

- Expected CI: `python -m unittest discover -s tests`
- No package release performed.