### PR TITLE
[codex] Harden file input and output safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Update installation documentation after the first verified PyPI publication.
+- Reject missing manifest inputs and symbolic links instead of producing ambiguous manifests.
+- Prevent CLI outputs from overwriting input files and write file outputs atomically.
+- Add executable smoke coverage for documented README command flows.
 
 ## 0.4.1 - 2026-06-07
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,7 @@ repro-evidence manifest create PATH -o manifest.json
 Each file entry includes relative path, byte size, and SHA-256.
 
 Manifest paths are serialized with `/` separators so manifests stay reviewable across platforms.
+The input must exist and must be a regular file or directory. Symbolic links are rejected, including links nested inside a directory tree, so a manifest cannot silently read outside its declared root.
 
 Use `--include` and `--exclude` to filter large artifact trees by manifest-relative path:
 
@@ -39,6 +40,7 @@ repro-evidence manifest diff before.json after.json -o diff.json
 The report groups paths into `added`, `removed`, `changed`, and `unchanged`.
 
 When comparing manifests, Windows-style `\` separators are treated as the same logical path separators as `/`.
+Output paths must not overwrite any input file. File outputs are written to a temporary sibling and atomically replaced after the complete content is flushed.
 
 Use `--format markdown` when you want a review-friendly Markdown report instead of JSON:
 

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -22,6 +22,15 @@ def _csv_list(values: list[str] | None) -> list[str]:
     return [part.strip() for value in values for part in value.split(",") if part.strip()]
 
 
+def _ensure_output_does_not_overwrite_input(output: Path | None, *inputs: Path | None) -> None:
+    if output is None:
+        return
+    output_path = output.resolve()
+    for input_path in inputs:
+        if input_path is not None and output_path == input_path.resolve():
+            raise ValueError(f"output must not overwrite input file: {input_path}")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="repro-evidence", description="Reproducible artifact manifest and evidence-bundle tools.")
     parser.add_argument("--version", action="version", version="repro-evidence 0.4.1")
@@ -87,6 +96,7 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         if args.command == "manifest" and args.manifest_command == "create":
+            _ensure_output_does_not_overwrite_input(args.output, args.path)
             write_json(
                 create_manifest(
                     args.path,
@@ -98,6 +108,7 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 0
         if args.command == "manifest" and args.manifest_command == "diff":
+            _ensure_output_does_not_overwrite_input(args.output, args.before, args.after)
             result = diff_manifests(load_json(args.before), load_json(args.after))
             if args.format == "markdown":
                 write_text(result.as_markdown(), args.output)
@@ -105,6 +116,7 @@ def main(argv: list[str] | None = None) -> int:
                 write_json(result.as_dict(), args.output)
             return 0
         if args.command == "verify" and args.verify_command == "sandbox-run":
+            _ensure_output_does_not_overwrite_input(args.output, args.before, args.after)
             result = verify_sandbox_output(
                 load_json(args.before),
                 load_json(args.after),
@@ -123,6 +135,7 @@ def main(argv: list[str] | None = None) -> int:
                 write_json(result, args.output)
             return 0 if result["ok"] else 1
         if args.command == "evidence" and args.evidence_command == "validate":
+            _ensure_output_does_not_overwrite_input(args.output, args.bundle, args.schema_path)
             bundle = load_evidence(args.bundle)
             result = validate_evidence_bundle_schema(bundle, args.schema_path) if args.schema else validate_evidence_bundle(bundle)
             if args.format == "junit":
@@ -137,13 +150,18 @@ def main(argv: list[str] | None = None) -> int:
                 return 0
             if args.output is None:
                 raise ValueError("evidence sign requires -o/--output unless --dry-run is used")
-            output_path = args.output.resolve()
-            if output_path in {args.bundle.resolve(), args.key.resolve()}:
-                raise ValueError("signature output must not overwrite the bundle or key file")
+            _ensure_output_does_not_overwrite_input(args.output, args.bundle, args.key)
             sidecar = sign_bundle(args.bundle, args.key, key_hint=args.key_hint)
             write_json(sidecar, args.output)
             return 0
         if args.command == "evidence" and args.evidence_command == "verify-signature":
+            _ensure_output_does_not_overwrite_input(
+                args.output,
+                args.bundle,
+                args.signature,
+                args.key,
+                args.schema_path,
+            )
             sidecar = load_signature_sidecar(args.signature)
             result = verify_bundle_signature(args.bundle, sidecar, args.key)
             if args.schema:

--- a/src/repro_evidence_kit/manifest.py
+++ b/src/repro_evidence_kit/manifest.py
@@ -4,6 +4,8 @@ import fnmatch
 import hashlib
 import json
 import os
+import stat
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -30,6 +32,12 @@ def iter_files(root: Path) -> Iterable[Path]:
         yield root
         return
     for dirpath, dirnames, filenames in os.walk(root):
+        current = Path(dirpath)
+        symlink_dirs = [current / name for name in dirnames if (current / name).is_symlink()]
+        symlink_files = [current / name for name in filenames if (current / name).is_symlink()]
+        symlinks = symlink_dirs + symlink_files
+        if symlinks:
+            raise ValueError(f"manifest input contains symlink: {symlinks[0]}")
         dirnames[:] = sorted(d for d in dirnames if d not in {".git", "__pycache__"})
         for name in sorted(filenames):
             yield Path(dirpath) / name
@@ -61,6 +69,12 @@ def create_manifest(
     include: Sequence[str] | None = None,
     exclude: Sequence[str] | None = None,
 ) -> dict[str, Any]:
+    if not root.exists():
+        raise ValueError(f"manifest input does not exist: {root}")
+    if root.is_symlink():
+        raise ValueError(f"manifest input must not be a symlink: {root}")
+    if not root.is_file() and not root.is_dir():
+        raise ValueError(f"manifest input must be a file or directory: {root}")
     root = root.resolve()
     include_patterns = normalize_filter_patterns(include)
     exclude_patterns = normalize_filter_patterns(exclude)
@@ -109,16 +123,32 @@ def write_json(data: Any, path: Path | None) -> None:
     if path is None:
         print(text, end="")
     else:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(text, encoding="utf-8")
+        atomic_write_text(text, path)
 
 
 def write_text(text: str, path: Path | None) -> None:
     if path is None:
         print(text, end="")
     else:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(text, encoding="utf-8")
+        atomic_write_text(text, path)
+
+
+def atomic_write_text(text: str, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing_mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else None
+    temp_path = path.parent / f".{path.name}.{uuid.uuid4().hex}.tmp"
+    fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            file.write(text)
+            file.flush()
+            os.fsync(file.fileno())
+        if existing_mode is not None:
+            os.chmod(temp_path, existing_mode)
+        os.replace(temp_path, path)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise
 
 
 @dataclass(frozen=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -277,6 +277,66 @@ class CliTests(unittest.TestCase):
             self.assertEqual(bundle.read_text(encoding="utf-8"), bundle_text)
             self.assertEqual(key.read_text(encoding="utf-8"), key_text)
 
+    def test_output_commands_refuse_to_overwrite_any_input(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            before = root / "before.json"
+            after = root / "after.json"
+            bundle = root / "bundle.json"
+            key = root / "key.txt"
+            signature = root / "bundle.sig.json"
+            before_text = json.dumps({"files": []})
+            after_text = json.dumps({"files": []})
+            bundle_text = json.dumps({
+                "schema_version": "1.0",
+                "title": "Synthetic",
+                "inputs": [],
+                "commands": [],
+                "outputs": [],
+            })
+            before.write_text(before_text, encoding="utf-8")
+            after.write_text(after_text, encoding="utf-8")
+            bundle.write_text(bundle_text, encoding="utf-8")
+            key.write_text("synthetic key\n", encoding="utf-8")
+            self.assertEqual(main(["evidence", "sign", str(bundle), "--key", str(key), "-o", str(signature)]), 0)
+
+            commands = [
+                ["manifest", "create", str(before), "-o", str(before)],
+                ["manifest", "diff", str(before), str(after), "-o", str(before)],
+                ["verify", "sandbox-run", str(before), str(after), "-o", str(after)],
+                ["evidence", "validate", str(bundle), "-o", str(bundle)],
+                [
+                    "evidence",
+                    "verify-signature",
+                    str(bundle),
+                    "--signature",
+                    str(signature),
+                    "--key",
+                    str(key),
+                    "-o",
+                    str(signature),
+                ],
+            ]
+            for command in commands:
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    code = main(command)
+                self.assertEqual(code, 2, command)
+                self.assertIn("must not overwrite", stderr.getvalue())
+
+            self.assertEqual(before.read_text(encoding="utf-8"), before_text)
+            self.assertEqual(after.read_text(encoding="utf-8"), after_text)
+            self.assertEqual(bundle.read_text(encoding="utf-8"), bundle_text)
+
+    def test_manifest_create_missing_input_returns_2(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                code = main(["manifest", "create", str(root / "missing")])
+            self.assertEqual(code, 2)
+            self.assertIn("does not exist", stderr.getvalue())
+
     @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
     def test_evidence_verify_signature_cli_schema_option(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
-from repro_evidence_kit.manifest import create_manifest, diff_manifests
+from repro_evidence_kit.manifest import create_manifest, diff_manifests, write_text
 
 
 class ManifestTests(unittest.TestCase):
@@ -79,6 +80,43 @@ class ManifestTests(unittest.TestCase):
             manifest = create_manifest(root)
         self.assertEqual([item["path"] for item in manifest["files"]], ["keep.txt", "noise.tmp"])
         self.assertNotIn("filters", manifest)
+
+    def test_create_manifest_rejects_missing_input(self):
+        with tempfile.TemporaryDirectory() as td:
+            missing = Path(td) / "missing"
+            with self.assertRaisesRegex(ValueError, "does not exist"):
+                create_manifest(missing)
+
+    def test_create_manifest_rejects_symlink_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            target = root / "target.txt"
+            target.write_text("target", encoding="utf-8")
+            link = root / "link.txt"
+            link.symlink_to(target)
+            with self.assertRaisesRegex(ValueError, "contains symlink"):
+                create_manifest(root)
+
+    def test_create_manifest_rejects_symlink_directory(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            target = root / "target"
+            target.mkdir()
+            (target / "file.txt").write_text("target", encoding="utf-8")
+            link = root / "link"
+            link.symlink_to(target, target_is_directory=True)
+            with self.assertRaisesRegex(ValueError, "contains symlink"):
+                create_manifest(root)
+
+    def test_atomic_write_preserves_original_if_replace_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            output = Path(td) / "result.txt"
+            output.write_text("original\n", encoding="utf-8")
+            with mock.patch("repro_evidence_kit.manifest.os.replace", side_effect=OSError("replace failed")):
+                with self.assertRaisesRegex(OSError, "replace failed"):
+                    write_text("replacement\n", output)
+            self.assertEqual(output.read_text(encoding="utf-8"), "original\n")
+            self.assertEqual(list(output.parent.glob(f".{output.name}.*.tmp")), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- reject missing manifest inputs and non-file/non-directory inputs
- reject symlink roots and symlinks nested inside manifest trees
- prevent every file-producing CLI command from overwriting any of its inputs
- write JSON, Markdown, JUnit, SARIF, and sidecar outputs through atomic sibling-file replacement
- document the safety policy and add regression coverage

## Why

A misspelled manifest path previously produced a successful empty manifest. Several commands could also overwrite their own input files when `-o` matched an input. Symlink behavior was implicit and surfaced as incidental path exceptions rather than an explicit policy.

## Impact

Invalid or ambiguous manifest inputs now fail with exit code 2, source inputs are preserved, and interrupted output replacement leaves an existing destination untouched. Symlinks are fail-closed rather than followed outside the declared root.

## Validation

- `python -m pytest -q` — 57 passed
- `PYTHONPATH=src python -m unittest discover -s tests -q` — 57 passed
- `python scripts/smoke_examples.py`
- release/install smoke for `.` and `.[schema]`
- `python -W error::SyntaxWarning -m compileall -q src tests`
- `git diff --check`