### PR TITLE
[codex] Validate manifest and SARIF contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Reject missing manifest inputs and symbolic links instead of producing ambiguous manifests.
 - Prevent CLI outputs from overwriting input files and write file outputs atomically.
 - Add executable smoke coverage for documented README command flows.
+- Add manifest and sandbox-SARIF schemas plus fail-closed manifest entry, metadata, and duplicate-path validation.
 
 ## 0.4.1 - 2026-06-07
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,6 +16,7 @@ Each file entry includes relative path, byte size, and SHA-256.
 
 Manifest paths are serialized with `/` separators so manifests stay reviewable across platforms.
 The input must exist and must be a regular file or directory. Symbolic links are rejected, including links nested inside a directory tree, so a manifest cannot silently read outside its declared root.
+Manifest consumers reject missing or malformed entry fields, unsupported versions, inconsistent file counts or byte totals, and duplicate logical paths after separator normalization.
 
 Use `--include` and `--exclude` to filter large artifact trees by manifest-relative path:
 

--- a/schemas/manifest.schema.json
+++ b/schemas/manifest.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/xodnr927-byte/repro-evidence-kit/schemas/manifest.schema.json",
+  "title": "Repro Evidence File Manifest",
+  "type": "object",
+  "required": ["files"],
+  "properties": {
+    "manifest_version": {"const": "1.0"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "root_name": {"type": "string"},
+    "file_count": {"type": "integer", "minimum": 0},
+    "total_bytes": {"type": "integer", "minimum": 0},
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "size", "sha256"],
+        "properties": {
+          "path": {"type": "string", "minLength": 1},
+          "size": {"type": "integer", "minimum": 0},
+          "sha256": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"},
+          "mtime_ns": {"type": "integer", "minimum": 0}
+        },
+        "additionalProperties": true
+      }
+    },
+    "filters": {"type": "object"}
+  },
+  "additionalProperties": true
+}

--- a/schemas/sandbox-sarif.schema.json
+++ b/schemas/sandbox-sarif.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/xodnr927-byte/repro-evidence-kit/schemas/sandbox-sarif.schema.json",
+  "title": "Repro Evidence Sandbox SARIF Output",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "$schema", "runs"],
+  "properties": {
+    "version": {"const": "2.1.0"},
+    "$schema": {"const": "https://json.schemastore.org/sarif-2.1.0.json"},
+    "runs": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["tool", "results"],
+        "properties": {
+          "tool": {
+            "type": "object",
+            "required": ["driver"],
+            "properties": {
+              "driver": {
+                "type": "object",
+                "required": ["name", "rules"],
+                "properties": {
+                  "name": {"const": "repro-evidence"},
+                  "rules": {"type": "array"}
+                }
+              }
+            }
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["ruleId", "level", "message", "locations"],
+              "properties": {
+                "ruleId": {
+                  "enum": [
+                    "unexpected-sandbox-change",
+                    "missing-required-sandbox-change"
+                  ]
+                },
+                "level": {"const": "error"},
+                "message": {
+                  "type": "object",
+                  "required": ["text"],
+                  "properties": {"text": {"type": "string"}}
+                },
+                "locations": {"type": "array", "minItems": 1}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/release_install_smoke.py
+++ b/scripts/release_install_smoke.py
@@ -38,6 +38,17 @@ def main(argv: list[str] | None = None) -> int:
         repro = bin_path(env, "repro-evidence")
         run([str(python), "-m", "pip", "install", args.source])
         run([str(repro), "--version"])
+        run([
+            str(python),
+            "-c",
+            (
+                "from importlib.resources import files; "
+                "root=files('repro_evidence_kit.schemas'); "
+                "names=('evidence-bundle.schema.json','signature-sidecar.schema.json',"
+                "'manifest.schema.json','sandbox-sarif.schema.json'); "
+                "assert all(root.joinpath(name).is_file() for name in names)"
+            ),
+        ])
 
         bundle = root / "evidence-bundle.yaml"
         key = root / "local-test.key"

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 from .evidence import evidence_result_as_junit, load_evidence, validate_evidence_bundle, validate_evidence_bundle_schema, validate_signature_sidecar_schema
-from .manifest import create_manifest, diff_manifests, load_json, write_json, write_text
+from .manifest import create_manifest, diff_manifests, load_manifest, write_json, write_text
 from .signing import load_signature_sidecar, sign_bundle, signature_verification_as_text, verify_bundle_signature
 from .verify import sandbox_result_as_junit, sandbox_result_as_sarif, verify_sandbox_output
 
@@ -109,7 +109,7 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         if args.command == "manifest" and args.manifest_command == "diff":
             _ensure_output_does_not_overwrite_input(args.output, args.before, args.after)
-            result = diff_manifests(load_json(args.before), load_json(args.after))
+            result = diff_manifests(load_manifest(args.before), load_manifest(args.after))
             if args.format == "markdown":
                 write_text(result.as_markdown(), args.output)
             else:
@@ -118,8 +118,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "verify" and args.verify_command == "sandbox-run":
             _ensure_output_does_not_overwrite_input(args.output, args.before, args.after)
             result = verify_sandbox_output(
-                load_json(args.before),
-                load_json(args.after),
+                load_manifest(args.before),
+                load_manifest(args.after),
                 allow_added=_csv_set(args.allow_added),
                 allow_changed=_csv_set(args.allow_changed),
                 allow_removed=_csv_set(args.allow_removed),

--- a/src/repro_evidence_kit/manifest.py
+++ b/src/repro_evidence_kit/manifest.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 MANIFEST_VERSION = "1.0"
+_HEX64 = set("0123456789abcdefABCDEF")
 
 
 def normalize_manifest_path(path: object) -> str:
@@ -115,6 +116,60 @@ def load_json(path: Path) -> dict[str, Any]:
         data = json.load(f)
     if not isinstance(data, dict):
         raise ValueError(f"expected JSON object in {path}")
+    return data
+
+
+def validate_manifest(data: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    files = data.get("files")
+    if not isinstance(files, list):
+        return ["files must be a list"]
+
+    seen: set[str] = set()
+    total_bytes = 0
+    for index, item in enumerate(files):
+        prefix = f"files[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+
+        path = item.get("path")
+        normalized_path: str | None = None
+        if not isinstance(path, str) or not path:
+            errors.append(f"{prefix}.path must be a non-empty string")
+        else:
+            normalized_path = normalize_manifest_path(path)
+            if normalized_path in seen:
+                errors.append(f"duplicate manifest path: {normalized_path}")
+            seen.add(normalized_path)
+
+        size = item.get("size")
+        if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+            errors.append(f"{prefix}.size must be a non-negative integer")
+        else:
+            total_bytes += size
+
+        sha256 = item.get("sha256")
+        if not isinstance(sha256, str) or len(sha256) != 64 or any(char not in _HEX64 for char in sha256):
+            errors.append(f"{prefix}.sha256 must be 64 hexadecimal characters")
+
+    manifest_version = data.get("manifest_version")
+    if manifest_version is not None and manifest_version != MANIFEST_VERSION:
+        errors.append(f"unsupported manifest_version: {manifest_version}")
+    file_count = data.get("file_count")
+    if file_count is not None and file_count != len(files):
+        errors.append(f"file_count does not match files length: {file_count} != {len(files)}")
+    recorded_total = data.get("total_bytes")
+    if recorded_total is not None and recorded_total != total_bytes:
+        errors.append(f"total_bytes does not match file sizes: {recorded_total} != {total_bytes}")
+    return errors
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    data = load_json(path)
+    errors = validate_manifest(data)
+    if errors:
+        raise ValueError(f"invalid manifest {path}: {'; '.join(errors)}")
     return data
 
 

--- a/src/repro_evidence_kit/schemas/manifest.schema.json
+++ b/src/repro_evidence_kit/schemas/manifest.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/xodnr927-byte/repro-evidence-kit/schemas/manifest.schema.json",
+  "title": "Repro Evidence File Manifest",
+  "type": "object",
+  "required": ["files"],
+  "properties": {
+    "manifest_version": {"const": "1.0"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "root_name": {"type": "string"},
+    "file_count": {"type": "integer", "minimum": 0},
+    "total_bytes": {"type": "integer", "minimum": 0},
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "size", "sha256"],
+        "properties": {
+          "path": {"type": "string", "minLength": 1},
+          "size": {"type": "integer", "minimum": 0},
+          "sha256": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"},
+          "mtime_ns": {"type": "integer", "minimum": 0}
+        },
+        "additionalProperties": true
+      }
+    },
+    "filters": {"type": "object"}
+  },
+  "additionalProperties": true
+}

--- a/src/repro_evidence_kit/schemas/sandbox-sarif.schema.json
+++ b/src/repro_evidence_kit/schemas/sandbox-sarif.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/xodnr927-byte/repro-evidence-kit/schemas/sandbox-sarif.schema.json",
+  "title": "Repro Evidence Sandbox SARIF Output",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "$schema", "runs"],
+  "properties": {
+    "version": {"const": "2.1.0"},
+    "$schema": {"const": "https://json.schemastore.org/sarif-2.1.0.json"},
+    "runs": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["tool", "results"],
+        "properties": {
+          "tool": {
+            "type": "object",
+            "required": ["driver"],
+            "properties": {
+              "driver": {
+                "type": "object",
+                "required": ["name", "rules"],
+                "properties": {
+                  "name": {"const": "repro-evidence"},
+                  "rules": {"type": "array"}
+                }
+              }
+            }
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["ruleId", "level", "message", "locations"],
+              "properties": {
+                "ruleId": {
+                  "enum": [
+                    "unexpected-sandbox-change",
+                    "missing-required-sandbox-change"
+                  ]
+                },
+                "level": {"const": "error"},
+                "message": {
+                  "type": "object",
+                  "required": ["text"],
+                  "properties": {"text": {"type": "string"}}
+                },
+                "locations": {"type": "array", "minItems": 1}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -337,6 +337,31 @@ class CliTests(unittest.TestCase):
             self.assertEqual(code, 2)
             self.assertIn("does not exist", stderr.getvalue())
 
+    def test_manifest_consumers_reject_malformed_and_duplicate_paths(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            valid = root / "valid.json"
+            malformed = root / "malformed.json"
+            duplicate = root / "duplicate.json"
+            valid.write_text(json.dumps({"files": []}), encoding="utf-8")
+            malformed.write_text(json.dumps({"files": [{"size": 1}]}), encoding="utf-8")
+            duplicate.write_text(json.dumps({
+                "files": [
+                    {"path": r"reports\result.json", "size": 1, "sha256": "a" * 64},
+                    {"path": "reports/result.json", "size": 1, "sha256": "a" * 64},
+                ]
+            }), encoding="utf-8")
+
+            for command, expected in (
+                (["manifest", "diff", str(malformed), str(valid)], "path must be a non-empty string"),
+                (["verify", "sandbox-run", str(duplicate), str(valid)], "duplicate manifest path"),
+            ):
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    code = main(command)
+                self.assertEqual(code, 2)
+                self.assertIn(expected, stderr.getvalue())
+
     @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
     def test_evidence_verify_signature_cli_schema_option(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -5,7 +5,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from repro_evidence_kit.manifest import create_manifest, diff_manifests, write_text
+from repro_evidence_kit.manifest import create_manifest, diff_manifests, load_manifest, validate_manifest, write_text
 
 
 class ManifestTests(unittest.TestCase):
@@ -117,6 +117,50 @@ class ManifestTests(unittest.TestCase):
                     write_text("replacement\n", output)
             self.assertEqual(output.read_text(encoding="utf-8"), "original\n")
             self.assertEqual(list(output.parent.glob(f".{output.name}.*.tmp")), [])
+
+    def test_validate_manifest_rejects_duplicate_normalized_paths(self):
+        errors = validate_manifest({
+            "files": [
+                {"path": r"reports\result.json", "size": 1, "sha256": "a" * 64},
+                {"path": "reports/result.json", "size": 1, "sha256": "a" * 64},
+            ]
+        })
+        self.assertIn("duplicate manifest path: reports/result.json", errors)
+
+    def test_validate_manifest_rejects_missing_or_malformed_entry_fields(self):
+        errors = validate_manifest({
+            "files": [
+                {"size": -1, "sha256": "bad"},
+                "not-an-object",
+            ]
+        })
+        self.assertIn("files[0].path must be a non-empty string", errors)
+        self.assertIn("files[0].size must be a non-negative integer", errors)
+        self.assertIn("files[0].sha256 must be 64 hexadecimal characters", errors)
+        self.assertIn("files[1] must be an object", errors)
+
+    def test_validate_manifest_rejects_inconsistent_metadata(self):
+        errors = validate_manifest({
+            "manifest_version": "2.0",
+            "file_count": 2,
+            "total_bytes": 9,
+            "files": [{"path": "a", "size": 1, "sha256": "a" * 64}],
+        })
+        self.assertIn("unsupported manifest_version: 2.0", errors)
+        self.assertIn("file_count does not match files length: 2 != 1", errors)
+        self.assertIn("total_bytes does not match file sizes: 9 != 1", errors)
+
+    def test_load_manifest_reports_validation_errors(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "manifest.json"
+            path.write_text('{"files": [{"size": 1}]}', encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, r"files\[0\]\.path"):
+                load_manifest(path)
+
+    def test_manifest_schema_copy_matches_packaged_copy(self):
+        repo_schema = Path("schemas/manifest.schema.json").read_text(encoding="utf-8")
+        packaged_schema = Path("src/repro_evidence_kit/schemas/manifest.schema.json").read_text(encoding="utf-8")
+        self.assertEqual(packaged_schema, repo_schema)
 
 
 if __name__ == "__main__":

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 import unittest
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
+from repro_evidence_kit.evidence import Draft202012Validator
 from repro_evidence_kit.verify import sandbox_result_as_junit, sandbox_result_as_sarif, verify_sandbox_output
 
 
@@ -97,6 +99,22 @@ class VerifyReportingTests(unittest.TestCase):
 
         self.assertEqual(run["results"], [])
         self.assertEqual({rule["id"] for rule in run["tool"]["driver"]["rules"]}, {"unexpected-sandbox-change", "missing-required-sandbox-change"})
+
+    @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
+    def test_sarif_output_matches_checked_in_schema(self):
+        result = verify_sandbox_output(
+            {"files": []},
+            {"files": [{"path": "report.json", "size": 2, "sha256": "a" * 64}]},
+        )
+        sarif = json.loads(sandbox_result_as_sarif(result))
+        schema = json.loads(Path("schemas/sandbox-sarif.schema.json").read_text(encoding="utf-8"))
+        errors = list(Draft202012Validator(schema).iter_errors(sarif))
+        self.assertEqual(errors, [])
+
+    def test_sarif_schema_copy_matches_packaged_copy(self):
+        repo_schema = Path("schemas/sandbox-sarif.schema.json").read_text(encoding="utf-8")
+        packaged_schema = Path("src/repro_evidence_kit/schemas/sandbox-sarif.schema.json").read_text(encoding="utf-8")
+        self.assertEqual(packaged_schema, repo_schema)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- add checked-in and packaged JSON Schemas for file manifests and emitted sandbox SARIF
- validate manifest entry shape, SHA-256 values, sizes, supported versions, file counts, and byte totals before diff or sandbox verification
- reject duplicate logical paths after Windows/POSIX separator normalization
- validate generated SARIF against the checked-in output contract
- verify all four packaged schemas in fresh-install and distribution smoke checks
- add malformed-input regression tests and documentation

## Why

Manifest consumers previously trusted arbitrary JSON objects. Missing paths produced opaque key errors, duplicate normalized paths were silently collapsed, and inconsistent metadata was accepted. SARIF output had field-level tests but no schema-level contract.

## Compatibility

Minimal manifests containing a valid `files` list remain supported. Metadata fields stay optional, but when supplied they must be internally consistent.

## Validation

- `python -m pytest -q` — 65 passed
- `PYTHONPATH=src python -m unittest discover -s tests -q` — 65 passed
- `python scripts/smoke_examples.py`
- release/install smoke for `.` and `.[schema]`
- wheel/sdist build plus `scripts/check_dist.py`
- wheel inspection confirmed both new packaged schemas
- Ruff — all checks passed
- syntax-warning compile check and `git diff --check`