### PR TITLE
[codex] Enforce static analysis and coverage gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Python ${{ matrix.python-version }}
@@ -25,6 +28,24 @@ jobs:
       - name: Leakage audit
         run: |
           ! grep -RInE 'PRO7|조조전|ekd5|EEX|S_44|R_44|Phase4|Frida|xdbg|Cao Cao|save editor|game mod|/mnt/c/Users/xodnr/Desktop/new|_modding_tools' . --exclude-dir=.git --exclude=ci.yml
+
+  quality:
+    name: Static analysis and coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: python -m pip install ".[dev]"
+      - run: ruff check src tests scripts
+      - run: mypy src
+      - run: coverage run -m unittest discover -s tests
+      - run: coverage report
+      - name: Verify tests do not depend on repository cwd
+        run: |
+          cd "$(mktemp -d)"
+          python -m unittest discover -s "$GITHUB_WORKSPACE/tests"
 
   package:
     name: Build package distributions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Prevent CLI outputs from overwriting input files and write file outputs atomically.
 - Add executable smoke coverage for documented README command flows.
 - Add manifest and sandbox-SARIF schemas plus fail-closed manifest entry, metadata, and duplicate-path validation.
+- Add enforced Ruff, Mypy, branch-coverage, and repository-independent test execution gates.
 
 ## 0.4.1 - 2026-06-07
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,14 @@ classifiers = [
 dependencies = ["PyYAML>=6.0"]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "jsonschema>=4.0"]
+dev = [
+  "coverage>=7.0",
+  "jsonschema>=4.0",
+  "mypy>=1.10",
+  "pytest>=8.0",
+  "ruff>=0.6",
+  "types-PyYAML>=6.0",
+]
 schema = ["jsonschema>=4.0"]
 
 [project.scripts]
@@ -43,3 +50,23 @@ Issues = "https://github.com/xodnr927-byte/repro-evidence-kit/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/repro_evidence_kit"]
+
+[tool.coverage.run]
+branch = true
+source = ["repro_evidence_kit"]
+
+[tool.coverage.report]
+fail_under = 88
+show_missing = true
+
+[tool.mypy]
+python_version = "3.10"
+files = ["src"]
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+[tool.ruff]
+target-version = "py310"
+line-length = 160

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -109,15 +109,15 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         if args.command == "manifest" and args.manifest_command == "diff":
             _ensure_output_does_not_overwrite_input(args.output, args.before, args.after)
-            result = diff_manifests(load_manifest(args.before), load_manifest(args.after))
+            manifest_diff = diff_manifests(load_manifest(args.before), load_manifest(args.after))
             if args.format == "markdown":
-                write_text(result.as_markdown(), args.output)
+                write_text(manifest_diff.as_markdown(), args.output)
             else:
-                write_json(result.as_dict(), args.output)
+                write_json(manifest_diff.as_dict(), args.output)
             return 0
         if args.command == "verify" and args.verify_command == "sandbox-run":
             _ensure_output_does_not_overwrite_input(args.output, args.before, args.after)
-            result = verify_sandbox_output(
+            sandbox_result = verify_sandbox_output(
                 load_manifest(args.before),
                 load_manifest(args.after),
                 allow_added=_csv_set(args.allow_added),
@@ -128,21 +128,21 @@ def main(argv: list[str] | None = None) -> int:
                 require_removed=_csv_set(args.require_removed),
             )
             if args.format == "junit":
-                write_text(sandbox_result_as_junit(result), args.output)
+                write_text(sandbox_result_as_junit(sandbox_result), args.output)
             elif args.format == "sarif":
-                write_text(sandbox_result_as_sarif(result), args.output)
+                write_text(sandbox_result_as_sarif(sandbox_result), args.output)
             else:
-                write_json(result, args.output)
-            return 0 if result["ok"] else 1
+                write_json(sandbox_result, args.output)
+            return 0 if sandbox_result["ok"] else 1
         if args.command == "evidence" and args.evidence_command == "validate":
             _ensure_output_does_not_overwrite_input(args.output, args.bundle, args.schema_path)
             bundle = load_evidence(args.bundle)
-            result = validate_evidence_bundle_schema(bundle, args.schema_path) if args.schema else validate_evidence_bundle(bundle)
+            evidence_result = validate_evidence_bundle_schema(bundle, args.schema_path) if args.schema else validate_evidence_bundle(bundle)
             if args.format == "junit":
-                write_text(evidence_result_as_junit(result), args.output)
+                write_text(evidence_result_as_junit(evidence_result), args.output)
             else:
-                write_json(result, args.output)
-            return 0 if result["ok"] else 1
+                write_json(evidence_result, args.output)
+            return 0 if evidence_result["ok"] else 1
         if args.command == "evidence" and args.evidence_command == "sign":
             if args.dry_run:
                 sidecar = sign_bundle(args.bundle, args.key, key_hint=args.key_hint)
@@ -163,16 +163,16 @@ def main(argv: list[str] | None = None) -> int:
                 args.schema_path,
             )
             sidecar = load_signature_sidecar(args.signature)
-            result = verify_bundle_signature(args.bundle, sidecar, args.key)
+            signature_result = verify_bundle_signature(args.bundle, sidecar, args.key)
             if args.schema:
                 schema_result = validate_signature_sidecar_schema(sidecar, args.schema_path)
-                result["schema"] = schema_result
-                result["ok"] = bool(result["ok"] and schema_result["ok"])
+                signature_result["schema"] = schema_result
+                signature_result["ok"] = bool(signature_result["ok"] and schema_result["ok"])
             if args.format == "text":
-                write_text(signature_verification_as_text(result), args.output)
+                write_text(signature_verification_as_text(signature_result), args.output)
             else:
-                write_json(result, args.output)
-            return 0 if result["ok"] else 1
+                write_json(signature_result, args.output)
+            return 0 if signature_result["ok"] else 1
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/src/repro_evidence_kit/evidence.py
+++ b/src/repro_evidence_kit/evidence.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import json
 import xml.etree.ElementTree as ET
-from importlib import resources
+from importlib import import_module, resources
 from pathlib import Path
 from typing import Any
 
 try:
-    import yaml
-except Exception:  # pragma: no cover
+    yaml: Any = import_module("yaml")
+except ImportError:  # pragma: no cover
     yaml = None
 
 try:
-    from jsonschema import Draft202012Validator
-except Exception:  # pragma: no cover
+    Draft202012Validator: Any = import_module("jsonschema").Draft202012Validator
+except ImportError:  # pragma: no cover
     Draft202012Validator = None
 
 REPO_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "evidence-bundle.schema.json"

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from repro_evidence_kit.evidence import Draft202012Validator, validate_evidence_bundle, validate_evidence_bundle_schema
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 class EvidenceTests(unittest.TestCase):
     def test_valid_bundle(self):
@@ -50,8 +52,8 @@ class EvidenceTests(unittest.TestCase):
         self.assertTrue(any("sha256" in error for error in schema_result["errors"]))
 
     def test_packaged_schema_matches_checked_in_schema(self):
-        repo_schema = Path("schemas/evidence-bundle.schema.json").read_text(encoding="utf-8")
-        packaged_schema = Path("src/repro_evidence_kit/schemas/evidence-bundle.schema.json").read_text(encoding="utf-8")
+        repo_schema = (REPO_ROOT / "schemas/evidence-bundle.schema.json").read_text(encoding="utf-8")
+        packaged_schema = (REPO_ROOT / "src/repro_evidence_kit/schemas/evidence-bundle.schema.json").read_text(encoding="utf-8")
         self.assertEqual(packaged_schema, repo_schema)
 
 
@@ -89,6 +91,6 @@ class SignatureSidecarSchemaTests(unittest.TestCase):
         self.assertTrue(any("algorithm" in error for error in result["errors"]))
 
     def test_packaged_signature_schema_matches_checked_in_schema(self):
-        repo_schema = Path("schemas/signature-sidecar.schema.json").read_text(encoding="utf-8")
-        packaged_schema = Path("src/repro_evidence_kit/schemas/signature-sidecar.schema.json").read_text(encoding="utf-8")
+        repo_schema = (REPO_ROOT / "schemas/signature-sidecar.schema.json").read_text(encoding="utf-8")
+        packaged_schema = (REPO_ROOT / "src/repro_evidence_kit/schemas/signature-sidecar.schema.json").read_text(encoding="utf-8")
         self.assertEqual(packaged_schema, repo_schema)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -7,6 +7,8 @@ from unittest import mock
 
 from repro_evidence_kit.manifest import create_manifest, diff_manifests, load_manifest, validate_manifest, write_text
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 class ManifestTests(unittest.TestCase):
     def test_create_manifest_hashes_files(self):
@@ -158,8 +160,8 @@ class ManifestTests(unittest.TestCase):
                 load_manifest(path)
 
     def test_manifest_schema_copy_matches_packaged_copy(self):
-        repo_schema = Path("schemas/manifest.schema.json").read_text(encoding="utf-8")
-        packaged_schema = Path("src/repro_evidence_kit/schemas/manifest.schema.json").read_text(encoding="utf-8")
+        repo_schema = (REPO_ROOT / "schemas/manifest.schema.json").read_text(encoding="utf-8")
+        packaged_schema = (REPO_ROOT / "src/repro_evidence_kit/schemas/manifest.schema.json").read_text(encoding="utf-8")
         self.assertEqual(packaged_schema, repo_schema)
 
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from repro_evidence_kit.evidence import Draft202012Validator
 from repro_evidence_kit.verify import sandbox_result_as_junit, sandbox_result_as_sarif, verify_sandbox_output
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 class VerifyTests(unittest.TestCase):
     def test_unexpected_added_path_fails(self):
@@ -107,13 +109,13 @@ class VerifyReportingTests(unittest.TestCase):
             {"files": [{"path": "report.json", "size": 2, "sha256": "a" * 64}]},
         )
         sarif = json.loads(sandbox_result_as_sarif(result))
-        schema = json.loads(Path("schemas/sandbox-sarif.schema.json").read_text(encoding="utf-8"))
+        schema = json.loads((REPO_ROOT / "schemas/sandbox-sarif.schema.json").read_text(encoding="utf-8"))
         errors = list(Draft202012Validator(schema).iter_errors(sarif))
         self.assertEqual(errors, [])
 
     def test_sarif_schema_copy_matches_packaged_copy(self):
-        repo_schema = Path("schemas/sandbox-sarif.schema.json").read_text(encoding="utf-8")
-        packaged_schema = Path("src/repro_evidence_kit/schemas/sandbox-sarif.schema.json").read_text(encoding="utf-8")
+        repo_schema = (REPO_ROOT / "schemas/sandbox-sarif.schema.json").read_text(encoding="utf-8")
+        packaged_schema = (REPO_ROOT / "src/repro_evidence_kit/schemas/sandbox-sarif.schema.json").read_text(encoding="utf-8")
         self.assertEqual(packaged_schema, repo_schema)
 
 


### PR DESCRIPTION
## What changed

- add Ruff, Mypy, and branch-coverage development dependencies and configuration
- fix all current Mypy findings without weakening runtime behavior
- enforce 88% minimum branch coverage in CI (current result: 91%)
- run the full test suite from an arbitrary working directory
- remove repository-cwd assumptions from schema contract tests
- set CI workflow permissions to read-only contents

## Why

The project had strong runtime tests but no enforced static-analysis or coverage quality gate. Several schema-copy tests also depended on being launched from the repository root.

## Validation

- Ruff: all checks passed
- Mypy: no issues in 8 source files
- branch coverage: 91%, minimum 88%
- unittest: 65 passed
- arbitrary-cwd unittest: 65 passed
- pytest: 65 passed
- `git diff --check`