### PR TITLE
[codex] Add supply chain automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,23 @@ jobs:
           cd "$(mktemp -d)"
           python -m unittest discover -s "$GITHUB_WORKSPACE/tests"
 
+  dependency-audit:
+    name: Dependency audit and SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: python -m pip install pip-audit
+      - run: pip-audit . --strict
+      - run: pip-audit . --strict --format cyclonedx-json --output dependency-sbom.cdx.json
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dependency-sbom
+          path: dependency-sbom.cdx.json
+          if-no-files-found: error
+
   package:
     name: Build package distributions
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ jobs:
   build:
     name: Build release distributions
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -23,6 +27,10 @@ jobs:
       - run: python -m pip install build twine
       - run: python -m build
       - run: python scripts/check_dist.py
+      - name: Generate build provenance attestations
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/*
       - uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
@@ -38,6 +46,7 @@ jobs:
       url: https://pypi.org/p/repro-evidence-kit
     permissions:
       id-token: write
+      contents: read
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add executable smoke coverage for documented README command flows.
 - Add manifest and sandbox-SARIF schemas plus fail-closed manifest entry, metadata, and duplicate-path validation.
 - Add enforced Ruff, Mypy, branch-coverage, and repository-independent test execution gates.
+- Add dependency auditing, CycloneDX SBOM artifacts, Dependabot updates, and release build-provenance attestations.
 
 ## 0.4.1 - 2026-06-07
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -33,6 +33,7 @@ environment name.
    - builds one wheel and one source distribution,
    - runs `twine check`,
    - smoke-installs and exercises both distributions,
+   - generates GitHub build-provenance attestations for the wheel and source distribution,
    - passes only the checked distributions to the OIDC-enabled publish job.
 6. Confirm the project and files appear on PyPI before changing README install
    instructions from tagged-source installation to package-index installation.
@@ -40,3 +41,17 @@ environment name.
 The workflow does not prove package semantics beyond its tests and smoke checks.
 Trusted Publishing identifies the authorized release workflow; it does not make
 the package or its outputs inherently trustworthy.
+
+## Dependency automation
+
+CI audits the project dependency graph with `pip-audit` and uploads a CycloneDX
+dependency SBOM as a workflow artifact. Dependabot checks both Python and
+GitHub Actions dependencies weekly. These controls report known dependency
+issues and update opportunities; they do not prove that dependencies or the
+resulting package are free of unknown vulnerabilities.
+
+Release artifacts can be verified against their GitHub build provenance with:
+
+```bash
+gh attestation verify PATH_TO_WHEEL_OR_SDIST -R xodnr927-byte/repro-evidence-kit
+```


### PR DESCRIPTION
## What changed

- add weekly Dependabot checks for Python and GitHub Actions dependencies
- add a strict `pip-audit` CI gate
- generate and upload a CycloneDX dependency SBOM from CI
- generate GitHub build-provenance attestations for release wheel/sdist artifacts with `actions/attest@v4`
- make release job permissions explicit and minimal for each job
- document audit, SBOM, attestation behavior, verification, and proof boundaries

## Validation

- project dependency audit: no known vulnerabilities
- CycloneDX output parsed successfully (`bomFormat=CycloneDX`, spec 1.4)
- actionlint: passed
- all workflow and Dependabot YAML parsed successfully
- `git diff --check`

These controls report known dependency issues and build origin; they do not prove package semantics or absence of unknown vulnerabilities.