### PR TITLE
[codex] Expand boundary input regression coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add manifest and sandbox-SARIF schemas plus fail-closed manifest entry, metadata, and duplicate-path validation.
 - Add enforced Ruff, Mypy, branch-coverage, and repository-independent test execution gates.
 - Add dependency auditing, CycloneDX SBOM artifacts, Dependabot updates, and release build-provenance attestations.
+- Add regression coverage for permission failures, interrupted writes, large manifests, Unicode paths, path collisions, and corrupted JSON/YAML/Schema inputs.
 
 ## 0.4.1 - 2026-06-07
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import tempfile
 import xml.etree.ElementTree as ET
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from repro_evidence_kit.cli import main
 from repro_evidence_kit.evidence import Draft202012Validator
@@ -361,6 +362,56 @@ class CliTests(unittest.TestCase):
                     code = main(command)
                 self.assertEqual(code, 2)
                 self.assertIn(expected, stderr.getvalue())
+
+    def test_corrupted_json_yaml_and_schema_inputs_return_2(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            broken_manifest = root / "broken-manifest.json"
+            broken_bundle_json = root / "broken-bundle.json"
+            broken_bundle_yaml = root / "broken-bundle.yaml"
+            broken_schema = root / "broken-schema.json"
+            valid_manifest = root / "valid-manifest.json"
+            valid_bundle = root / "valid-bundle.json"
+            broken_manifest.write_text('{"files": [', encoding="utf-8")
+            broken_bundle_json.write_text('{"title": ', encoding="utf-8")
+            broken_bundle_yaml.write_text("title: [unterminated", encoding="utf-8")
+            broken_schema.write_text('{"type": ', encoding="utf-8")
+            valid_manifest.write_text('{"files": []}', encoding="utf-8")
+            valid_bundle.write_text(json.dumps({
+                "schema_version": "1.0",
+                "title": "Synthetic",
+                "inputs": [],
+                "commands": [],
+                "outputs": [],
+            }), encoding="utf-8")
+
+            commands = [
+                ["manifest", "diff", str(broken_manifest), str(valid_manifest)],
+                ["evidence", "validate", str(broken_bundle_json)],
+                ["evidence", "validate", str(broken_bundle_yaml)],
+                ["evidence", "validate", str(valid_bundle), "--schema", "--schema-path", str(broken_schema)],
+            ]
+            for command in commands:
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    code = main(command)
+                self.assertEqual(code, 2, command)
+                self.assertIn("error:", stderr.getvalue())
+
+    def test_unwritable_output_returns_2_without_partial_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            source = root / "source.txt"
+            output = root / "manifest.json"
+            source.write_text("source", encoding="utf-8")
+            stderr = io.StringIO()
+            with mock.patch("repro_evidence_kit.manifest.os.open", side_effect=PermissionError("permission denied")):
+                with contextlib.redirect_stderr(stderr):
+                    code = main(["manifest", "create", str(source), "-o", str(output)])
+            self.assertEqual(code, 2)
+            self.assertIn("permission denied", stderr.getvalue())
+            self.assertFalse(output.exists())
+            self.assertEqual(list(root.glob(f".{output.name}.*.tmp")), [])
 
     @unittest.skipIf(Draft202012Validator is None, "jsonschema optional dependency is not installed")
     def test_evidence_verify_signature_cli_schema_option(self):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -120,6 +120,37 @@ class ManifestTests(unittest.TestCase):
             self.assertEqual(output.read_text(encoding="utf-8"), "original\n")
             self.assertEqual(list(output.parent.glob(f".{output.name}.*.tmp")), [])
 
+    def test_atomic_write_permission_failure_preserves_original(self):
+        with tempfile.TemporaryDirectory() as td:
+            output = Path(td) / "result.txt"
+            output.write_text("original\n", encoding="utf-8")
+            with mock.patch("repro_evidence_kit.manifest.os.open", side_effect=PermissionError("permission denied")):
+                with self.assertRaisesRegex(PermissionError, "permission denied"):
+                    write_text("replacement\n", output)
+            self.assertEqual(output.read_text(encoding="utf-8"), "original\n")
+            self.assertEqual(list(output.parent.glob(f".{output.name}.*.tmp")), [])
+
+    def test_create_manifest_handles_large_file_set_deterministically(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            for index in range(1500):
+                (root / f"artifact-{index:04d}.txt").write_text(str(index), encoding="utf-8")
+            manifest = create_manifest(root)
+        paths = [item["path"] for item in manifest["files"]]
+        self.assertEqual(manifest["file_count"], 1500)
+        self.assertEqual(paths, sorted(paths))
+        self.assertEqual(paths[0], "artifact-0000.txt")
+        self.assertEqual(paths[-1], "artifact-1499.txt")
+
+    def test_create_manifest_preserves_unicode_and_special_paths(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            names = ["space name.txt", "보고서-한글.json", "emoji-😀.bin", "brackets-[draft].txt"]
+            for name in names:
+                (root / name).write_text(name, encoding="utf-8")
+            manifest = create_manifest(root)
+        self.assertEqual([item["path"] for item in manifest["files"]], sorted(names))
+
     def test_validate_manifest_rejects_duplicate_normalized_paths(self):
         errors = validate_manifest({
             "files": [


### PR DESCRIPTION
## What changed

- test permission-denied output without source or partial-file damage
- retain the existing interrupted atomic-replace regression
- exercise deterministic manifests over 1,500 files
- cover Unicode, spaces, emoji, and bracketed filenames
- exercise corrupted manifest JSON, evidence JSON/YAML, and custom JSON Schema inputs
- retain normalized Windows/POSIX path-collision coverage

## Validation

- focused pytest: 40 passed
- full unittest: 70 passed
- Ruff: all checks passed
- Mypy: no issues in 8 source files
- branch coverage: 91% (minimum 88%)
- `git diff --check`

No production behavior needed to change: the current fail-closed and atomic-write implementations passed these new boundary predicates.