### PR TITLE
[codex] Prepare v0.4.2 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.12'
       - name: Confirm tag matches package version
         run: |
-          package_version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          package_version="$(python -c 'import runpy; print(runpy.run_path("src/repro_evidence_kit/__init__.py")["__version__"])')"
           test "$GITHUB_REF_NAME" = "v$package_version"
       - run: python -m pip install build twine
       - run: python -m build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.2 - 2026-06-13
+
 - Update installation documentation after the first verified PyPI publication.
 - Reject missing manifest inputs and symbolic links instead of producing ambiguous manifests.
 - Prevent CLI outputs from overwriting input files and write file outputs atomically.
@@ -10,6 +12,7 @@
 - Add enforced Ruff, Mypy, branch-coverage, and repository-independent test execution gates.
 - Add dependency auditing, CycloneDX SBOM artifacts, Dependabot updates, and release build-provenance attestations.
 - Add regression coverage for permission failures, interrupted writes, large manifests, Unicode paths, path collisions, and corrupted JSON/YAML/Schema inputs.
+- Use one package version source for build metadata and CLI version output.
 
 ## 0.4.1 - 2026-06-07
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,16 @@
 
 ## Recently completed
 
+### v0.4.2
+
+- Fail-closed manifest input, symlink, duplicate-path, and metadata validation.
+- Atomic file outputs and input-overwrite protection.
+- Manifest and sandbox-SARIF schemas with packaged contract checks.
+- Executable README command smoke coverage.
+- Ruff, Mypy, branch-coverage, and arbitrary-working-directory quality gates.
+- Dependency auditing, CycloneDX SBOM artifacts, Dependabot, and release build provenance.
+- Boundary coverage for permission failures, large trees, Unicode paths, and corrupted structured inputs.
+
 ### v0.4.1
 
 - PyPI publication completed.
@@ -30,8 +40,7 @@
 ## Near-term polish
 
 - Keep examples synthetic-only.
-- Expand CI recipes for signed-bundle verification and example smoke checks.
-- Add contract and schema tests for the existing SARIF output.
+- Review future changes against the v0.4.2 file-safety and validation contracts.
 
 ## Later ideas
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repro-evidence-kit"
-version = "0.4.1"
+dynamic = ["version"]
 description = "Reproducible artifact manifests, sandbox-output verification, and evidence-bundle validation."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -50,6 +50,9 @@ Issues = "https://github.com/xodnr927-byte/repro-evidence-kit/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/repro_evidence_kit"]
+
+[tool.hatch.version]
+path = "src/repro_evidence_kit/__init__.py"
 
 [tool.coverage.run]
 branch = true

--- a/src/repro_evidence_kit/__init__.py
+++ b/src/repro_evidence_kit/__init__.py
@@ -1,3 +1,3 @@
 """Reproducible artifact evidence toolkit."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from . import __version__
 from .evidence import evidence_result_as_junit, load_evidence, validate_evidence_bundle, validate_evidence_bundle_schema, validate_signature_sidecar_schema
 from .manifest import create_manifest, diff_manifests, load_manifest, write_json, write_text
 from .signing import load_signature_sidecar, sign_bundle, signature_verification_as_text, verify_bundle_signature
@@ -33,7 +34,7 @@ def _ensure_output_does_not_overwrite_input(output: Path | None, *inputs: Path |
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="repro-evidence", description="Reproducible artifact manifest and evidence-bundle tools.")
-    parser.add_argument("--version", action="version", version="repro-evidence 0.4.1")
+    parser.add_argument("--version", action="version", version=f"repro-evidence {__version__}")
     sub = parser.add_subparsers(dest="command", required=True)
 
     manifest = sub.add_parser("manifest", help="Create or compare file manifests")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,11 +9,19 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from repro_evidence_kit import __version__
 from repro_evidence_kit.cli import main
 from repro_evidence_kit.evidence import Draft202012Validator
 
 
 class CliTests(unittest.TestCase):
+    def test_version_uses_package_version(self):
+        with self.assertRaises(SystemExit) as raised:
+            with contextlib.redirect_stdout(io.StringIO()) as stdout:
+                main(["--version"])
+        self.assertEqual(raised.exception.code, 0)
+        self.assertEqual(stdout.getvalue().strip(), f"repro-evidence {__version__}")
+
     def test_manifest_create_cli(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
## Release scope

Prepare v0.4.2 with all merged file-safety, manifest/SARIF validation, quality-gate, supply-chain, and boundary-regression work.

## Changes

- move the package version to one source: `src/repro_evidence_kit/__init__.py`
- derive Hatch build metadata and CLI `--version` from that source
- update the release tag/version verification workflow for dynamic metadata
- finalize the v0.4.2 changelog and roadmap

## Validation

- pytest: 71 passed
- unittest: 71 passed
- Ruff: passed
- Mypy: passed
- branch coverage: 91%
- editable metadata version: 0.4.2
- CLI version: 0.4.2
- wheel/sdist: built as 0.4.2 and passed twine/install smoke checks
- actionlint: passed
- `git diff --check`