### PR TITLE
[codex] Refresh GitHub Actions cookbook versions

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -30,8 +30,8 @@ jobs:
   evidence:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python -m pip install -e .
@@ -52,13 +52,13 @@ jobs:
   manifest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python -m pip install -e .
       - run: python -m repro_evidence_kit manifest create examples/dummy-binary -o manifest.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: manifest
           path: manifest.json
@@ -78,8 +78,8 @@ jobs:
   evidence:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python -m pip install -e ".[schema]"
@@ -99,7 +99,7 @@ jobs:
           python -m repro_evidence_kit evidence validate \
             examples/evidence-bundle.yaml \
             --schema
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: filtered-evidence
           path: filtered-manifest.json
@@ -119,8 +119,8 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python -m pip install -e .
@@ -147,8 +147,8 @@ jobs:
   verify-report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python -m pip install -e .
@@ -163,7 +163,7 @@ jobs:
             --require-added report.json \
             --format junit \
             -o sandbox-verification.xml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: sandbox-verification-junit
@@ -186,8 +186,8 @@ jobs:
   signed-evidence:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python -m pip install -e ".[schema]"
@@ -217,8 +217,8 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python -m pip install -e .
@@ -239,8 +239,8 @@ jobs:
   sandbox-sarif:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python -m pip install -e .
@@ -254,7 +254,7 @@ jobs:
             --require-added report.json \
             --format sarif \
             -o sandbox-verification.sarif
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: sandbox-verification-sarif
@@ -268,7 +268,7 @@ jobs:
     python -m repro_evidence_kit evidence validate examples/evidence-bundle.yaml \
       --format junit \
       -o evidence-validation.xml
-- uses: actions/upload-artifact@v4
+- uses: actions/upload-artifact@v7
   if: always()
   with:
     name: evidence-validation-junit


### PR DESCRIPTION
## What changed

- update every cookbook example to `actions/checkout@v6`
- update every Python setup example to `actions/setup-python@v6`
- update artifact upload examples to `actions/upload-artifact@v7`

## Why

The live workflows already use the Node 24-compatible action majors, but `docs/github-actions.md` still showed the older versions. This keeps the copyable documentation aligned with the repository's verified workflow baseline without changing runtime behavior.

## Scope

Documentation only. No source, test, workflow, package, or release changes.

## Validation

- stale action-reference grep: none
- `git diff --check`
- `uv run pytest -q`: 71 passed
- `uv run --extra schema pytest -q`: 71 passed
- `python3 scripts/smoke_examples.py`: passed
