### PR TITLE
[codex] Add Windows filesystem CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,17 @@ jobs:
         run: |
           ! grep -RInE 'PRO7|조조전|ekd5|EEX|S_44|R_44|Phase4|Frida|xdbg|Cao Cao|save editor|game mod|/mnt/c/Users/xodnr/Desktop/new|_modding_tools' . --exclude-dir=.git --exclude=ci.yml
 
+  windows-filesystem:
+    name: Windows filesystem contract
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: python -m pip install ".[schema]"
+      - run: python -m unittest discover -s tests
+
   quality:
     name: Static analysis and coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- add a bounded Windows/Python 3.12 CI job
- run the public test suite on the Windows filesystem surface
- keep the existing Ubuntu Python 3.10/3.11/3.12 matrix unchanged

## Why

The project had no live Windows runner proof for path normalization, input/output collision checks, atomic-write failure handling, Unicode paths, or applicable symlink behavior. These predicates already exist in the public tests; this PR executes them on Windows rather than adding platform-specific substitutes.

## Impact

CI gains one Windows job. Product behavior, package metadata, and trust-boundary claims are unchanged.

## Validation

- workflow YAML parsed successfully
- `git diff --check`
- `uv run pytest -q` — 71 passed
- `uv run --extra schema pytest -q` — 71 passed

The draft should remain open until the actual `windows-latest` job passes.
