### PR TITLE
[codex] Upload sandbox policy SARIF

### DIFF
--- a/.github/workflows/sandbox-sarif.yml
+++ b/.github/workflows/sandbox-sarif.yml
@@ -1,0 +1,39 @@
+name: Sandbox SARIF upload
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    name: Upload sandbox-policy SARIF
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: python -m pip install .
+      - name: Generate synthetic sandbox-policy SARIF
+        run: |
+          mkdir -p sandbox
+          printf 'input\n' > sandbox/input.txt
+          python -m repro_evidence_kit manifest create sandbox -o before.json
+          printf '{"ok": true}\n' > sandbox/report.json
+          python -m repro_evidence_kit manifest create sandbox -o after.json
+          python -m repro_evidence_kit verify sandbox-run before.json after.json \
+            --allow-added report.json \
+            --require-added report.json \
+            --format sarif \
+            -o sandbox-verification.sarif
+      - uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: sandbox-verification.sarif
+          category: repro-evidence-sandbox-policy

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -229,6 +229,16 @@ jobs:
 
 Use this when a downstream code-scanning integration accepts SARIF. The SARIF report is a compact policy-failure adapter for sandbox output verification.
 
+The repository's optional `.github/workflows/sandbox-sarif.yml` workflow
+generates a synthetic passing report and uploads it to GitHub Code Scanning on
+pushes to `main`. It grants `security-events: write` only to the upload job and
+does not run on pull requests, where untrusted forks do not receive write
+permissions.
+
+This integration publishes sandbox allowlist/required-output findings. It is
+not vulnerability analysis, source-code scanning, or evidence that an artifact
+is safe.
+
 ```yaml
 name: Sandbox SARIF
 


### PR DESCRIPTION
## Summary

- add a `main`-push workflow that generates a synthetic passing sandbox-policy SARIF report
- upload the report through `github/codeql-action/upload-sarif@v4`
- grant `security-events: write` only to the upload job
- document the integration's narrow claim boundary

## Why

The CLI already emits schema-tested SARIF, but the repository had not proved that GitHub Code Scanning can consume it. This workflow exercises the real upload path without publishing proprietary data or manufacturing a synthetic alert.

## Impact

On pushes to `main`, GitHub Code Scanning receives one synthetic sandbox-policy analysis with zero findings. The workflow does not run on pull requests, avoiding write-permission failures for untrusted forks.

This publishes sandbox allowlist/required-output findings only. It is not vulnerability analysis, source-code scanning, or evidence that an artifact is safe.

## Validation

- workflow YAML parsed successfully
- `git diff --check`
- synthetic generation produced SARIF 2.1.0 with one run and zero findings
- `uv run pytest -q` — 71 passed

The actual Code Scanning upload must be verified on the post-merge `main` run before this integration is considered proven.
