### PR TITLE
[codex] Clarify manifest provenance boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The project is intentionally target-neutral. It should help maintainers in CI, r
 
 ## Features
 
-- Create deterministic SHA-256 manifests for files or filtered directory trees.
+- Create SHA-256 manifests with deterministic file ordering and per-file digests for files or filtered directory trees.
 - Diff two manifests to identify added, removed, changed, and unchanged artifacts.
 - Verify sandbox/experiment outputs against explicit allowlists, with optional JUnit XML for CI report consumers.
 - Validate simple YAML or JSON evidence bundles, with optional JSON Schema checks.
@@ -60,7 +60,8 @@ For local development:
 ```bash
 python -m venv .venv
 . .venv/bin/activate
-pip install -e .
+pip install -e ".[dev]"
+pytest -q
 ```
 
 ## Quick start
@@ -76,6 +77,8 @@ For larger artifact trees, filter manifests with explicit include/exclude patter
 ```bash
 repro-evidence manifest create artifacts --include reports --exclude "*.tmp" -o manifest.json
 ```
+
+Manifest file ordering and per-file digests are deterministic for identical inputs. The manifest document itself includes `created_at`, so its complete JSON bytes are not identical across runs. Generated manifests also disclose the built-in `.git` and `__pycache__` directory exclusions in `implicit_excluded_directories`.
 
 For stricter evidence-bundle checks, install the optional schema extra and validate against the checked-in JSON Schema:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,7 +28,9 @@ repro-evidence manifest create artifacts \
   -o manifest.json
 ```
 
-Filters are deterministic and use POSIX-style manifest-relative globs or subtree paths. Includes run first; when at least one include is supplied, only matching files remain. Excludes run after includes and remove matching files. Repeated flags and comma-separated values are accepted. When filters are used, the manifest records normalized include/exclude patterns in a `filters` metadata object.
+Filters are deterministic and use POSIX-style manifest-relative globs or subtree paths. Includes run first; when at least one include is supplied, only matching files remain. Excludes run after includes and remove matching files. Repeated flags and comma-separated values are accepted. When filters are used, the manifest records normalized include/exclude patterns in a `filters` metadata object. Every generated manifest also records the built-in `.git` and `__pycache__` directory exclusions in `implicit_excluded_directories`.
+
+File ordering and per-file digests are deterministic for identical inputs. The complete manifest JSON document is not byte-identical across runs because it records a wall-clock `created_at` value.
 
 ## `manifest diff`
 

--- a/docs/signed-bundles.md
+++ b/docs/signed-bundles.md
@@ -66,6 +66,8 @@ Current sidecar fields, also covered by `schemas/signature-sidecar.schema.json`:
 }
 ```
 
+The HMAC authenticates the exact evidence-bundle payload bytes. Sidecar envelope metadata is not itself included in that HMAC; fields such as `key_hint` are advisory labels and must not be treated as authenticated signer identity.
+
 ## Canonical payload rule
 
 The first implementation should sign exact file bytes or a clearly documented canonical serialization, not an implicit Python object. Exact file bytes are simpler and reduce surprise, but they make whitespace and key ordering part of the signed payload. If canonical serialization is chosen later, it must be documented and covered by round-trip tests before release.

--- a/docs/why-not-just.md
+++ b/docs/why-not-just.md
@@ -10,7 +10,7 @@ Its purpose is narrower: provide a low-friction review surface for generated or 
 
 `repro-evidence-kit` adds:
 
-- deterministic directory manifests,
+- deterministic file ordering and per-file digests in directory manifests,
 - include/exclude filtering,
 - added/removed/changed/unchanged classification,
 - evidence-bundle metadata,
@@ -18,6 +18,8 @@ Its purpose is narrower: provide a low-friction review surface for generated or 
 - optional CI report formats.
 
 A hash still proves only byte identity. It does not prove semantic correctness.
+
+Generated manifests include a wall-clock `created_at` value, so the complete manifest JSON document is not byte-identical across runs. They record the built-in `.git` and `__pycache__` directory exclusions in `implicit_excluded_directories`.
 
 ## Why not just `git diff`?
 

--- a/schemas/manifest.schema.json
+++ b/schemas/manifest.schema.json
@@ -10,6 +10,11 @@
     "root_name": {"type": "string"},
     "file_count": {"type": "integer", "minimum": 0},
     "total_bytes": {"type": "integer", "minimum": 0},
+    "implicit_excluded_directories": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
     "files": {
       "type": "array",
       "items": {

--- a/src/repro_evidence_kit/manifest.py
+++ b/src/repro_evidence_kit/manifest.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 MANIFEST_VERSION = "1.0"
+IMPLICIT_EXCLUDED_DIRECTORIES = (".git", "__pycache__")
 _HEX64 = set("0123456789abcdefABCDEF")
 
 
@@ -39,7 +40,7 @@ def iter_files(root: Path) -> Iterable[Path]:
         symlinks = symlink_dirs + symlink_files
         if symlinks:
             raise ValueError(f"manifest input contains symlink: {symlinks[0]}")
-        dirnames[:] = sorted(d for d in dirnames if d not in {".git", "__pycache__"})
+        dirnames[:] = sorted(d for d in dirnames if d not in IMPLICIT_EXCLUDED_DIRECTORIES)
         for name in sorted(filenames):
             yield Path(dirpath) / name
 
@@ -99,6 +100,7 @@ def create_manifest(
         "root_name": root.name,
         "file_count": len(entries),
         "total_bytes": sum(e["size"] for e in entries),
+        "implicit_excluded_directories": list(IMPLICIT_EXCLUDED_DIRECTORIES),
         "files": entries,
     }
     if include_patterns or exclude_patterns:

--- a/src/repro_evidence_kit/schemas/manifest.schema.json
+++ b/src/repro_evidence_kit/schemas/manifest.schema.json
@@ -10,6 +10,11 @@
     "root_name": {"type": "string"},
     "file_count": {"type": "integer", "minimum": 0},
     "total_bytes": {"type": "integer", "minimum": 0},
+    "implicit_excluded_directories": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
     "files": {
       "type": "array",
       "items": {

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -83,6 +83,18 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual([item["path"] for item in manifest["files"]], ["keep.txt", "noise.tmp"])
         self.assertNotIn("filters", manifest)
 
+    def test_create_manifest_records_and_applies_implicit_directory_exclusions(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "keep.txt").write_text("keep", encoding="utf-8")
+            for excluded in (".git", "__pycache__"):
+                directory = root / excluded
+                directory.mkdir()
+                (directory / "ignored.txt").write_text("ignored", encoding="utf-8")
+            manifest = create_manifest(root)
+        self.assertEqual(manifest["implicit_excluded_directories"], [".git", "__pycache__"])
+        self.assertEqual([item["path"] for item in manifest["files"]], ["keep.txt"])
+
     def test_create_manifest_rejects_missing_input(self):
         with tempfile.TemporaryDirectory() as td:
             missing = Path(td) / "missing"


### PR DESCRIPTION
## What changed

- scope manifest determinism claims to deterministic file ordering and per-file digests;
- disclose the built-in `.git` and `__pycache__` directory exclusions in generated manifest metadata;
- use one traversal/metadata source of truth for those exclusions;
- add schema and regression-test coverage for the new metadata;
- document that HMAC authenticates bundle bytes, while advisory sidecar metadata such as `key_hint` is outside that authenticated payload;
- make the README development setup install dev dependencies and run the documented test command.

## Why

A genuine external review cloned the repository and reproduced that identical input trees generate different complete manifest JSON hashes because `created_at` changes. The implementation's file ordering and digests are deterministic, but the broader documentation wording could imply byte-deterministic manifest documents.

The same review identified that built-in directory exclusions were applied but not disclosed in manifest provenance, and that the signed-sidecar envelope boundary deserved explicit wording.

External review: https://thecolony.cc/post/32a1240e-2592-4d40-852c-5089223670a6

Closes #56.

## Compatibility

Existing manifest readers remain compatible: the new field is additive, both schemas already allow additional properties, and manifest diff behavior remains file-entry based.

## Validation

- `uv run pytest -q` — 72 passed
- `uv run --extra schema pytest -q` — 72 passed
- `uv run ruff check .` — passed
- `uv run mypy src` — passed
- `python3 scripts/smoke_examples.py` — passed
- `python3 scripts/release_install_smoke.py .` — passed
- `python3 scripts/release_install_smoke.py '.[schema]'` — passed
- coverage suite — 72 passed, 91% total
- `git diff --check` — passed
