### PR TITLE
[codex] Document release governance evidence

### DIFF
--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -53,3 +53,34 @@ See [Publishing to PyPI](publishing.md) for the Trusted Publishing setup and
 release flow. PyPI publishing is triggered by a release and uses tokenless
 Trusted Publishing/OIDC credentials. This authorization mechanism does not
 prove package correctness.
+
+## Repository governance evidence
+
+Repository settings are live control-plane state and can drift independently
+of tracked files. Before a release or external governance review, query the
+current settings instead of relying on this document alone:
+
+```bash
+gh api repos/xodnr927-byte/repro-evidence-kit/branches/main/protection
+gh api repos/xodnr927-byte/repro-evidence-kit \
+  --jq '{delete_branch_on_merge,allow_squash_merge,allow_merge_commit,allow_rebase_merge}'
+```
+
+The verified June 15, 2026 snapshot required pull requests, strict up-to-date
+status checks, conversation resolution, linear history, stale-review
+dismissal, and seven CI contexts. Force pushes and branch deletion were
+disabled. The required approving-review count was `0`, administrator
+enforcement was disabled, and automatic deletion of merged branches was
+enabled. The approval and administrator-bypass settings must not be described
+as independent-review enforcement.
+
+GitHub Actions currently use maintained major-version tags rather than immutable
+commit SHAs. This keeps Dependabot updates readable and avoids manually
+maintaining action hashes, but it accepts the upstream risk that a mutable major
+tag can move. Treat SHA pinning or an action allowlist as future hardening,
+especially if the repository gains additional maintainers or handles more
+sensitive release credentials.
+
+The sandbox SARIF workflow uses job-scoped `security-events: write`. Verify
+actual ingestion through the Code Scanning analyses API; workflow existence or
+a successful generation step alone is not ingestion proof.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -28,14 +28,46 @@ Use this checklist before tagging a release. It is maintainer guidance, not a tr
 
 ## After tagging
 
-1. Install from the tagged source reference in a fresh environment.
-2. Check the CLI version:
+1. Confirm the GitHub release points to the intended tag and commit, and that
+   the publish workflow completed successfully.
+2. Download the published wheel and source distribution from the workflow
+   evidence surface and verify their GitHub build-provenance attestations:
+   ```bash
+   gh attestation verify PATH_TO_WHEEL_OR_SDIST \
+     -R xodnr927-byte/repro-evidence-kit
+   ```
+3. Confirm the dependency-audit job produced its CycloneDX SBOM artifact.
+   Record the workflow-run URL because workflow artifacts are retention-bound.
+4. After PyPI shows the new version, install both the base package and schema
+   extra from PyPI in separate fresh environments:
+   ```bash
+   python -m pip install "repro-evidence-kit==X.Y.Z"
+   python -m pip install "repro-evidence-kit[schema]==X.Y.Z"
+   ```
+5. Check the CLI version:
    ```bash
    repro-evidence --version
    ```
-3. Run minimal evidence signing and verification with synthetic local key material.
-4. Mutate the bundle bytes and confirm verification returns exit code `1`.
-5. Do not publish live keys, private fixtures, proprietary samples, or target-specific evidence.
+6. Run the README quick-start commands from a directory outside the source
+   checkout.
+7. Run minimal evidence signing and verification with synthetic local key
+   material.
+8. Mutate the bundle bytes and confirm verification returns exit code `1`.
+9. Confirm the latest `main` Code Scanning analysis includes category
+   `repro-evidence-sandbox-policy` with no ingestion error:
+   ```bash
+   gh api \
+     "repos/xodnr927-byte/repro-evidence-kit/code-scanning/analyses?per_page=10" \
+     --jq '.[] | select(.category == "repro-evidence-sandbox-policy") |
+       {ref, commit_sha, category, error, created_at}'
+   ```
+   A successful upload proves GitHub accepted the SARIF document. It does not
+   prove package correctness or that every future upload will succeed.
+10. Record the release URL, publish-workflow URL, PyPI version, attestation
+    result, SBOM artifact location, quick-start result, and Code Scanning
+    analysis ID in the release notes or maintainer evidence record.
+11. Do not publish live keys, private fixtures, proprietary samples, or
+    target-specific evidence.
 
 For the one-time Trusted Publisher setup and automated release flow, see
 [Publishing to PyPI](publishing.md).


### PR DESCRIPTION
## What changed

- expand the post-tag release checklist with PyPI base/schema installs, attestation verification, SBOM evidence, README smoke, and Code Scanning ingestion checks;
- document how to query live branch-protection and repository settings;
- record the verified June 15, 2026 governance boundary without overstating independent review;
- document the current major-tag Actions policy and the future SHA-pinning tradeoff;
- distinguish SARIF workflow existence from Code Scanning ingestion evidence.

## Repository setting

Automatic deletion of merged branches was enabled. Approval count and administrator enforcement were intentionally left unchanged because those require a broader solo-maintainer governance decision.

## Validation

- `uv run pytest -q` — 71 passed
- `uv run --extra schema pytest -q` — 71 passed
- `python3 scripts/smoke_examples.py` — passed
- GitHub Markdown rendering for both edited documents — passed
- `git diff --check` — passed
- repository setting readback: `delete_branch_on_merge: true`
