### PR TITLE
[codex] Guard empty filtered manifests

### DIFF
--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -45,6 +45,7 @@ def build_parser() -> argparse.ArgumentParser:
     create.add_argument("--include-mtime", action="store_true")
     create.add_argument("--include", action="append", help="Manifest-relative glob or subtree path to include; may be repeated or comma-separated")
     create.add_argument("--exclude", action="append", help="Manifest-relative glob or subtree path to exclude after includes; may be repeated or comma-separated")
+    create.add_argument("--allow-empty", action="store_true", help="Allow filters to select zero files instead of failing")
 
     diff = manifest_sub.add_parser("diff", help="Compare two JSON manifests")
     diff.add_argument("before", type=Path)
@@ -104,6 +105,7 @@ def main(argv: list[str] | None = None) -> int:
                     include_mtime=args.include_mtime,
                     include=_csv_list(args.include),
                     exclude=_csv_list(args.exclude),
+                    allow_empty=args.allow_empty,
                 ),
                 args.output,
             )

--- a/src/repro_evidence_kit/manifest.py
+++ b/src/repro_evidence_kit/manifest.py
@@ -17,7 +17,10 @@ _HEX64 = set("0123456789abcdefABCDEF")
 
 def normalize_manifest_path(path: object) -> str:
     """Return the manifest's portable logical path form."""
-    return str(path).replace("\\", "/")
+    normalized = str(path).replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
 
 
 def sha256_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
@@ -47,7 +50,8 @@ def iter_files(root: Path) -> Iterable[Path]:
 def normalize_filter_patterns(patterns: Sequence[str] | None) -> list[str]:
     if not patterns:
         return []
-    return sorted({normalize_manifest_path(pattern.strip()) for pattern in patterns if pattern.strip()})
+    normalized = {normalize_manifest_path(pattern.strip()) for pattern in patterns if pattern.strip()}
+    return sorted(pattern for pattern in normalized if pattern)
 
 
 def path_matches_filter(path: str, pattern: str) -> bool:
@@ -69,6 +73,7 @@ def create_manifest(
     include_mtime: bool = False,
     include: Sequence[str] | None = None,
     exclude: Sequence[str] | None = None,
+    allow_empty: bool = False,
 ) -> dict[str, Any]:
     if not root.exists():
         raise ValueError(f"manifest input does not exist: {root}")
@@ -93,6 +98,9 @@ def create_manifest(
         if include_mtime:
             item["mtime_ns"] = st.st_mtime_ns
         entries.append(item)
+    filters_requested = bool(include_patterns or exclude_patterns)
+    if filters_requested and not entries and not allow_empty:
+        raise ValueError("manifest filters selected no files; use --allow-empty to write an empty filtered manifest")
     manifest: dict[str, Any] = {
         "manifest_version": MANIFEST_VERSION,
         "created_at": datetime.now(timezone.utc).isoformat(),
@@ -101,7 +109,7 @@ def create_manifest(
         "total_bytes": sum(e["size"] for e in entries),
         "files": entries,
     }
-    if include_patterns or exclude_patterns:
+    if filters_requested:
         manifest["filters"] = {
             "include": include_patterns,
             "exclude": exclude_patterns,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,6 +112,29 @@ class CliTests(unittest.TestCase):
             self.assertEqual(data["filters"]["include"], ["reports"])
             self.assertEqual(data["filters"]["exclude"], ["*.log"])
 
+    def test_manifest_create_cli_rejects_empty_filtered_selection(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "keep.txt").write_text("keep", encoding="utf-8")
+            output = root / "manifest.json"
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                code = main(["manifest", "create", str(root), "--include", "missing", "-o", str(output)])
+            self.assertEqual(code, 2)
+            self.assertIn("filters selected no files", stderr.getvalue())
+            self.assertFalse(output.exists())
+
+    def test_manifest_create_cli_allows_empty_filtered_selection_when_explicit(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "keep.txt").write_text("keep", encoding="utf-8")
+            output = root / "manifest.json"
+            code = main(["manifest", "create", str(root), "--include", "missing", "--allow-empty", "-o", str(output)])
+            self.assertEqual(code, 0)
+            data = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(data["file_count"], 0)
+            self.assertEqual(data["files"], [])
+
     def test_verify_sandbox_junit_output_keeps_failure_exit_code(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -83,6 +83,32 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual([item["path"] for item in manifest["files"]], ["keep.txt", "noise.tmp"])
         self.assertNotIn("filters", manifest)
 
+    def test_create_manifest_filters_normalize_leading_dot_slash(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "reports").mkdir()
+            (root / "reports" / "result.json").write_text("{}", encoding="utf-8")
+            (root / "keep.txt").write_text("keep", encoding="utf-8")
+            manifest = create_manifest(root, exclude=["./reports"])
+        self.assertEqual([item["path"] for item in manifest["files"]], ["keep.txt"])
+        self.assertEqual(manifest["filters"]["exclude"], ["reports"])
+
+    def test_create_manifest_rejects_empty_filtered_selection_by_default(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "keep.txt").write_text("keep", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "filters selected no files"):
+                create_manifest(root, include=["missing"])
+
+    def test_create_manifest_allows_empty_filtered_selection_when_explicit(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "keep.txt").write_text("keep", encoding="utf-8")
+            manifest = create_manifest(root, include=["missing"], allow_empty=True)
+        self.assertEqual(manifest["file_count"], 0)
+        self.assertEqual(manifest["files"], [])
+        self.assertEqual(manifest["filters"]["include"], ["missing"])
+
     def test_create_manifest_rejects_missing_input(self):
         with tempfile.TemporaryDirectory() as td:
             missing = Path(td) / "missing"


### PR DESCRIPTION
## Summary

- Normalize leading `./` in manifest filter patterns before matching/storing them.
- Reject filtered manifest creation when include/exclude filters select zero files by default.
- Add an explicit `--allow-empty` CLI override for intentional empty filtered manifests.

## Why

An empty filtered manifest can otherwise look like a successful artifact inventory even when the filter was mistyped. The new default fails closed while keeping an explicit compatibility escape hatch.

## Validation

- `uv run pytest -q` — 76 passed
- `uv run --extra schema pytest -q` — 76 passed
- `python3 scripts/smoke_examples.py` — passed

## Boundary

This is a narrow manifest-filter guard. It does not resolve issue #56's broader determinism/exclusions/schema/signature-sidecar documentation acceptance criteria.