### PR TITLE
[codex] Document external review hold ledger

### DIFF
--- a/docs/external-review-ledger.md
+++ b/docs/external-review-ledger.md
@@ -1,0 +1,68 @@
+# External review ledger
+
+This ledger records external review feedback without treating it as already
+implemented or accepted. It is a holding surface for review-window triage, not a
+fix list.
+
+## Hold policy
+
+- External-review feedback is collected during the current ownership window.
+- Do not merge, close, or implement external-review findings from this ledger
+  before **2026-06-18 01:21 UTC** unless the maintainer explicitly lifts the
+  hold.
+- During the hold, allowed actions are limited to collecting links, classifying
+  the claim, preserving attribution, and recording current proof boundaries.
+- A Colony-only comment is discovery evidence. Durable project records remain
+  GitHub issues, pull requests, discussions, releases, or documented release
+  evidence.
+
+## Current repository queue
+
+Snapshot date: 2026-06-16.
+
+| Item | State | Boundary | Next action after hold |
+| --- | --- | --- | --- |
+| PR #57, manifest provenance boundaries | Open, ready-for-review, behind `main` | External review window remains active until 2026-06-18 01:21 UTC. | Re-check reviews, threads, mergeability, and CI before any merge. |
+| PR #58, signer trust policy | Open draft, behind `main` | Design-only. Does not implement signer trust, key rotation, revocation, or identity trust. | Rebase after PR #57, then review against issue #53. |
+| PR #60, empty filtered manifest guard | Open draft, clean, CI green | Narrow filter guard only. Not merged or released; does not close the broader provenance/design work. | Decide whether to keep draft, mark ready, or merge after attribution/hold review. |
+| Issue #56, manifest determinism and implicit exclusions | Open | Tracks provenance wording, implicit exclusions, schema coverage, and sidecar-boundary docs. | Close only after the merged PR state satisfies the acceptance criteria. |
+| Issue #53, signer trust/key rotation/revocation | Open | Design problem; current docs must not imply implementation. | Split implementation tasks only after design review is merged. |
+
+## External feedback queue
+
+| Source | Feedback | Classification | Current status | Deferred action |
+| --- | --- | --- | --- | --- |
+| Reticuli, The Colony | `--include` filters that match no files produced a successful empty manifest. | Confirmed external finding; false-green risk. | Addressed only in draft PR #60; not merged/released. | Preserve attribution; decide PR #60 after hold. |
+| Reticuli, The Colony | `--exclude './reports'` did not match like `--exclude 'reports/'`. | Confirmed external finding; path-normalization risk. | Addressed only in draft PR #60; not merged/released. | Preserve attribution; decide PR #60 after hold. |
+| Reticuli, The Colony | Manifest document is not byte-reproducible because `created_at` changes. | Claim-precision/provenance gap. | Tracked by issue #56 and PR #57; `created_at` intentionally remains. | Re-check PR #57 after hold. |
+| Reticuli, The Colony | Built-in `.git` and `__pycache__` skips were not disclosed in manifest metadata. | Confirmed provenance disclosure gap. | Tracked by issue #56 and PR #57. | Re-check PR #57 after hold. |
+| CauseClaw, The Colony | Raw-clone test path needed clearer dev dependency setup. | Adoption/documentation friction. | Tracked by PR #57 docs changes; not current `main`. | Re-check PR #57 after hold. |
+| ∫ΔI Seed / Exori, The Colony | Artifact verification does not prove process provenance or an independent re-runner. | Design gap candidate, not an implemented feature and not an execution-verified defect. | Related to issue #53 / PR #58 design lane. | Keep design-only; require a concrete schema field, command, or verification predicate before implementation. |
+| eliza-gemma, The Colony | Windows long path / MAX_PATH behavior may fail in deep artifact trees. | Potential risk; not execution-verified by the reporter. | Existing Windows CI does not prove this exact predicate. | After hold, consider a small Windows-only repro test/report before any broad rewrite. |
+| eliza-gemma, The Colony | SARIF schema edge cases may be invalid under strict downstream validation. | Hypothesis until tested against a validator and concrete output. | No current defect claim. | After hold, route through a validator-backed fixture if reopened. |
+| voixgrave, The Colony | Voice perception research may be a useful artifact-review use case. | Possible use case, not repo proof and not a defect. | Needs fixture, command, and expected predicate. | Do not count as adoption proof without a runnable example. |
+
+## Validation snapshot
+
+Local checks run on 2026-06-16 from `main` after creating this ledger branch:
+
+- `uv run pytest -q` -> 71 passed
+- `uv run --extra schema pytest -q` -> 71 passed
+- `python3 scripts/smoke_examples.py` -> passed
+
+GitHub check snapshot for PR #60 on 2026-06-16:
+
+- Python 3.10, 3.11, and 3.12 -> pass
+- Windows filesystem contract -> pass
+- Static analysis and coverage -> pass
+- Dependency audit and SBOM -> pass
+- Build package distributions -> pass
+
+## Non-goals before the hold expires
+
+- Do not merge PR #57, PR #58, or PR #60.
+- Do not implement Windows long-path, SARIF, process-provenance, or voice-domain
+  follow-up work.
+- Do not close issues #53 or #56.
+- Do not claim external-review findings are resolved on `main` until merged and
+  revalidated.

--- a/docs/external-review-ledger.md
+++ b/docs/external-review-ledger.md
@@ -1,68 +1,67 @@
 # External review ledger
 
-This ledger records external review feedback without treating it as already
-implemented or accepted. It is a holding surface for review-window triage, not a
-fix list.
+This ledger records external review feedback without treating it as broader than
+its evidence. It separates collected comments, merged fixes, design-only work,
+and still-unproven risks.
 
-## Hold policy
+## Review-window policy
 
-- External-review feedback is collected during the current ownership window.
-- Do not merge, close, or implement external-review findings from this ledger
-  before **2026-06-18 01:21 UTC** unless the maintainer explicitly lifts the
-  hold.
-- During the hold, allowed actions are limited to collecting links, classifying
-  the claim, preserving attribution, and recording current proof boundaries.
-- A Colony-only comment is discovery evidence. Durable project records remain
-  GitHub issues, pull requests, discussions, releases, or documented release
-  evidence.
+- The external-review ownership window ran through **2026-06-18 01:21 UTC**.
+- During that window, external feedback was collected and classified rather than
+  immediately merged or closed.
+- After the window, each finding still needs a current GitHub/CI check before it
+  can be merged, closed, or promoted into a release claim.
+- A Colony-only or Moltbook-only comment is discovery evidence. Durable project
+  records remain GitHub issues, pull requests, discussions, releases, or
+  documented release evidence.
 
 ## Current repository queue
 
-Snapshot date: 2026-06-16.
+Snapshot date: 2026-06-18.
 
-| Item | State | Boundary | Next action after hold |
+| Item | State | Boundary | Next action |
 | --- | --- | --- | --- |
-| PR #57, manifest provenance boundaries | Open, ready-for-review, behind `main` | External review window remains active until 2026-06-18 01:21 UTC. | Re-check reviews, threads, mergeability, and CI before any merge. |
-| PR #58, signer trust policy | Open draft, behind `main` | Design-only. Does not implement signer trust, key rotation, revocation, or identity trust. | Rebase after PR #57, then review against issue #53. |
-| PR #60, empty filtered manifest guard | Open draft, clean, CI green | Narrow filter guard only. Not merged or released; does not close the broader provenance/design work. | Decide whether to keep draft, mark ready, or merge after attribution/hold review. |
-| Issue #56, manifest determinism and implicit exclusions | Open | Tracks provenance wording, implicit exclusions, schema coverage, and sidecar-boundary docs. | Close only after the merged PR state satisfies the acceptance criteria. |
+| PR #57, manifest provenance boundaries | Merged after fresh CI | Narrows manifest determinism wording, records implicit directory exclusions, updates schema copies, and documents the sidecar-boundary wording. | Use merged `main` evidence when deciding issue #56 closure. |
+| PR #60, empty filtered manifest guard | Merged after conflict resolution and fresh CI | Narrow filter guard only: zero-file filtered selections fail by default and `--allow-empty` is explicit. | Include in the next release notes as a false-green fix. |
+| PR #61, external review ledger | Open draft | Documentation-only holding and classification surface. | Merge only after this snapshot matches current `main`. |
+| PR #58, signer trust policy | Open draft, behind `main` | Design-only. Does not implement signer trust, key rotation, revocation, process provenance, or identity trust. | Rebase/update after the merged manifest work; keep design-only until reviewed against issue #53. |
+| Issue #56, manifest determinism and implicit exclusions | Open at snapshot time | Tracks provenance wording, implicit exclusions, schema coverage, and sidecar-boundary docs. | Close only if current merged `main` satisfies the acceptance criteria. |
 | Issue #53, signer trust/key rotation/revocation | Open | Design problem; current docs must not imply implementation. | Split implementation tasks only after design review is merged. |
 
 ## External feedback queue
 
-| Source | Feedback | Classification | Current status | Deferred action |
+| Source | Feedback | Classification | Current status | Follow-up |
 | --- | --- | --- | --- | --- |
-| Reticuli, The Colony | `--include` filters that match no files produced a successful empty manifest. | Confirmed external finding; false-green risk. | Addressed only in draft PR #60; not merged/released. | Preserve attribution; decide PR #60 after hold. |
-| Reticuli, The Colony | `--exclude './reports'` did not match like `--exclude 'reports/'`. | Confirmed external finding; path-normalization risk. | Addressed only in draft PR #60; not merged/released. | Preserve attribution; decide PR #60 after hold. |
-| Reticuli, The Colony | Manifest document is not byte-reproducible because `created_at` changes. | Claim-precision/provenance gap. | Tracked by issue #56 and PR #57; `created_at` intentionally remains. | Re-check PR #57 after hold. |
-| Reticuli, The Colony | Built-in `.git` and `__pycache__` skips were not disclosed in manifest metadata. | Confirmed provenance disclosure gap. | Tracked by issue #56 and PR #57. | Re-check PR #57 after hold. |
-| CauseClaw, The Colony | Raw-clone test path needed clearer dev dependency setup. | Adoption/documentation friction. | Tracked by PR #57 docs changes; not current `main`. | Re-check PR #57 after hold. |
+| Reticuli, The Colony | `--include` filters that match no files produced a successful empty manifest. | Confirmed external finding; false-green risk. | Merged via PR #60. | Preserve external attribution in release notes. |
+| Reticuli, The Colony | `--exclude './reports'` did not match like `--exclude 'reports/'`. | Confirmed external finding; path-normalization risk. | Merged via PR #60. | Preserve external attribution in release notes. |
+| Reticuli, The Colony | Manifest document is not byte-reproducible because `created_at` changes. | Claim-precision/provenance gap. | Addressed by PR #57 wording; `created_at` intentionally remains. | Do not claim byte-reproducible manifest documents. |
+| Reticuli, The Colony | Built-in `.git` and `__pycache__` skips were not disclosed in manifest metadata. | Confirmed provenance disclosure gap. | Merged via PR #57 as `implicit_excluded_directories`. | Verify schema/readers before closing issue #56. |
+| CauseClaw, The Colony | Raw-clone test path needed clearer dev dependency setup. | Adoption/documentation friction. | Addressed by PR #57 docs changes on `main`. | Keep README setup wording scoped to actual dev dependencies. |
 | ∫ΔI Seed / Exori, The Colony | Artifact verification does not prove process provenance or an independent re-runner. | Design gap candidate, not an implemented feature and not an execution-verified defect. | Related to issue #53 / PR #58 design lane. | Keep design-only; require a concrete schema field, command, or verification predicate before implementation. |
-| eliza-gemma, The Colony | Windows long path / MAX_PATH behavior may fail in deep artifact trees. | Potential risk; not execution-verified by the reporter. | Existing Windows CI does not prove this exact predicate. | After hold, consider a small Windows-only repro test/report before any broad rewrite. |
-| eliza-gemma, The Colony | SARIF schema edge cases may be invalid under strict downstream validation. | Hypothesis until tested against a validator and concrete output. | No current defect claim. | After hold, route through a validator-backed fixture if reopened. |
+| eliza-gemma, The Colony | Windows long path / MAX_PATH behavior may fail in deep artifact trees. | Potential risk; not execution-verified by the reporter. | Existing Windows CI does not prove this exact predicate. | Consider a small Windows-only repro test/report before any broad rewrite. |
+| eliza-gemma, The Colony | SARIF schema edge cases may be invalid under strict downstream validation. | Hypothesis until tested against a validator and concrete output. | No current defect claim. | Route through a validator-backed fixture if reopened. |
 | voixgrave, The Colony | Voice perception research may be a useful artifact-review use case. | Possible use case, not repo proof and not a defect. | Needs fixture, command, and expected predicate. | Do not count as adoption proof without a runnable example. |
 
 ## Validation snapshot
 
-Local checks run on 2026-06-16 from `main` after creating this ledger branch:
+Local checks run on 2026-06-18 after merging `main` into this ledger branch:
 
-- `uv run pytest -q` -> 71 passed
-- `uv run --extra schema pytest -q` -> 71 passed
+- `uv run pytest -q` -> 77 passed
+- `uv run --extra schema pytest -q` -> 77 passed
 - `python3 scripts/smoke_examples.py` -> passed
 
-GitHub check snapshot for PR #60 on 2026-06-16:
+GitHub check snapshots used before merge:
 
-- Python 3.10, 3.11, and 3.12 -> pass
-- Windows filesystem contract -> pass
-- Static analysis and coverage -> pass
-- Dependency audit and SBOM -> pass
-- Build package distributions -> pass
+- PR #57 after branch update: all required checks passed, then merged.
+- PR #60 after conflict resolution against PR #57: all required checks passed,
+  then merged.
+- PR #61 before merge: rerun required after this ledger update.
 
-## Non-goals before the hold expires
+## Non-goals still active
 
-- Do not merge PR #57, PR #58, or PR #60.
 - Do not implement Windows long-path, SARIF, process-provenance, or voice-domain
-  follow-up work.
-- Do not close issues #53 or #56.
-- Do not claim external-review findings are resolved on `main` until merged and
-  revalidated.
+  follow-up work from this ledger without a separate scoped issue or PR.
+- Do not claim signer trust, key rotation, revocation, process provenance, or
+  disjoint re-runner identity as implemented until code and verification exist.
+- Do not count external comments as adoption proof without a durable artifact,
+  issue, PR, release evidence, or runnable example.

--- a/docs/maintainer-workflow.md
+++ b/docs/maintainer-workflow.md
@@ -2,6 +2,10 @@
 
 `repro-evidence-kit` is designed for maintainers who need small, reviewable proof around generated artifacts.
 
+## External review hold
+
+Use the [external review ledger](external-review-ledger.md) to collect outside feedback during review windows. The ledger is a holding surface: do not convert external comments into implementation, merge, release, or issue-closure claims until the active hold expires and the relevant PRs are rechecked.
+
 ## Pull request review
 
 A maintainer can ask contributors to include:


### PR DESCRIPTION
## Summary

- Add `docs/external-review-ledger.md` as a holding surface for external feedback during the active review window.
- Record current PR/issue queue state, external feedback classifications, validation snapshots, and explicit non-goals before the hold expires.
- Link the ledger from `docs/maintainer-workflow.md`.

## Why

External comments are useful discovery evidence, but the current policy is to collect and classify them during the 3-day ownership window rather than immediately implementing, merging, or closing findings.

## Boundary

This is documentation-only. It does not implement Windows long-path handling, SARIF validation changes, process-provenance features, signer-trust features, or merge/close any open PR or issue.

## Validation

- `uv run pytest -q` — 71 passed
- `uv run --extra schema pytest -q` — 71 passed
- `python3 scripts/smoke_examples.py` — passed