### PR TITLE
Add local signer key resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Add a synthetic-only signer trust policy schema/parser for issue #62. It
   validates local `env:`/`file:` key references, rejects duplicate or embedded
   key material, and does not implement key resolution, signing, or verification.
+- Add synthetic-only local `env:`/`file:` key resolver interfaces for issue #63
+  with stable fail-closed errors. Resolution does not authorize policy state,
+  sign, verify, or establish signer identity.
 
 ## 0.4.2 - 2026-06-13
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,10 +54,10 @@
 - Review future changes against the v0.4.2 file-safety and validation contracts.
 - Design signer trust, key rotation, and revocation policy in
   [issue #53](https://github.com/xodnr927-byte/repro-evidence-kit/issues/53)
-  before expanding the signed-sidecar prototype. The current proposal is
-  documented in
-  [docs/signer-trust-policy.md](docs/signer-trust-policy.md) for review; no
-  policy-aware implementation is included.
+  before expanding the signed-sidecar prototype. The policy parser and local
+  synthetic `env:`/`file:` resolver interfaces are documented in
+  [docs/signer-trust-policy.md](docs/signer-trust-policy.md); policy-aware
+  verification and signing remain separate follow-up work.
 
 ## Later ideas
 

--- a/docs/signer-trust-policy.md
+++ b/docs/signer-trust-policy.md
@@ -134,6 +134,23 @@ would move signer selection into attacker-controlled input.
 Signing should require an `active` key. Verification may use `active` or
 `verify_only`; it must reject `revoked`.
 
+## Local key resolvers
+
+`repro_evidence_kit.key_resolver` resolves only parser-approved `env:` and
+`file:` references. Environment values become UTF-8 bytes; files are read as
+exact bytes without trimming or decoding. Empty material, missing references,
+unreadable files, malformed references, unsupported schemes, and multiple
+resolvers claiming the same scheme fail closed with stable
+`KeyResolutionError.code` values.
+
+Absolute file references use the default file resolver. A relative file
+reference requires an explicit `FileKeyResolver(base_directory=...)`; it never
+falls back to the process working directory.
+
+Resolution returns key bytes only. It does not select a policy key, authorize a
+key state, verify a signature, or permit signing. Fixtures remain synthetic;
+policy files and repository content must not contain live key material.
+
 ## Rotation
 
 Rotation uses an explicit overlap period:
@@ -213,7 +230,9 @@ Implementation should remain split into independently reviewable work:
    implemented by `repro_evidence_kit.trust_policy` and the packaged
    `trust-policy.schema.json` copies; resolver and authorization behavior remain
    separate follow-up work.
-3. Add resolver interfaces with synthetic environment/file fixtures.
+3. Add resolver interfaces with synthetic environment/file fixtures. This is
+   implemented by `repro_evidence_kit.key_resolver`; authorization, signing,
+   and verification remain separate.
 4. Add policy-aware verification and stable structured error categories.
 5. Add policy-aware signing only after verification behavior is reviewed.
 

--- a/src/repro_evidence_kit/key_resolver.py
+++ b/src/repro_evidence_kit/key_resolver.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Mapping, Protocol
+
+from .trust_policy import SUPPORTED_RESOLVERS, TrustPolicyKey
+
+
+_ENV_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class KeyResolutionError(ValueError):
+    """Fail-closed local key-resolution error with a stable machine-readable code."""
+
+    def __init__(self, code: str, message: str, *, key_ref: str) -> None:
+        self.code = code
+        self.key_ref = key_ref
+        self.details = ({"code": code, "key_ref": key_ref, "message": message},)
+        super().__init__(f"{code}: {message}")
+
+
+class KeyResolver(Protocol):
+    """Interface for one local, parser-approved key-reference scheme."""
+
+    scheme: str
+
+    def resolve(self, reference: str) -> bytes:
+        """Return the exact key bytes for the scheme-specific reference."""
+        ...
+
+
+@dataclass(frozen=True)
+class EnvironmentKeyResolver:
+    """Resolve key bytes from one explicitly named environment variable."""
+
+    environment: Mapping[str, str] | None = None
+    scheme: str = field(default="env", init=False)
+
+    def resolve(self, reference: str) -> bytes:
+        key_ref = f"{self.scheme}:{reference}"
+        environment = os.environ if self.environment is None else self.environment
+        if reference not in environment:
+            raise KeyResolutionError("key_reference_missing", "environment variable is not set", key_ref=key_ref)
+        try:
+            return environment[reference].encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise KeyResolutionError("malformed_key_material", "environment value is not valid UTF-8 text", key_ref=key_ref) from exc
+
+
+@dataclass(frozen=True)
+class FileKeyResolver:
+    """Resolve exact key bytes from a local file path."""
+
+    base_directory: Path | None = None
+    scheme: str = field(default="file", init=False)
+
+    def resolve(self, reference: str) -> bytes:
+        key_ref = f"{self.scheme}:{reference}"
+        path = Path(reference)
+        if not path.is_absolute():
+            if self.base_directory is None:
+                raise KeyResolutionError("ambiguous_key_reference", "relative key file requires an explicit base directory", key_ref=key_ref)
+            path = self.base_directory / path
+        try:
+            return path.read_bytes()
+        except FileNotFoundError as exc:
+            raise KeyResolutionError("key_reference_missing", "key file does not exist", key_ref=key_ref) from exc
+        except OSError as exc:
+            raise KeyResolutionError("key_reference_unreadable", "key file could not be read", key_ref=key_ref) from exc
+
+
+def _split_key_reference(key_ref: str) -> tuple[str, str]:
+    if not isinstance(key_ref, str) or key_ref != key_ref.strip() or any(ord(char) < 32 or ord(char) == 127 for char in key_ref):
+        raise KeyResolutionError("invalid_key_reference", "key reference must be a trimmed string without control characters", key_ref=str(key_ref))
+    scheme, separator, reference = key_ref.partition(":")
+    if not separator or scheme not in SUPPORTED_RESOLVERS:
+        raise KeyResolutionError("unsupported_resolver", "key reference must use the env: or file: resolver scheme", key_ref=key_ref)
+    if scheme == "env" and _ENV_NAME.fullmatch(reference) is None:
+        raise KeyResolutionError("invalid_key_reference", "env: reference must contain one environment-variable name", key_ref=key_ref)
+    if scheme == "file" and (not reference or reference.startswith("//")):
+        raise KeyResolutionError("invalid_key_reference", "file: reference must contain a local path, not a remote URL", key_ref=key_ref)
+    return scheme, reference
+
+
+def resolve_key_reference(key_ref: str, *, resolvers: Iterable[KeyResolver] | None = None) -> bytes:
+    """Resolve one parser-approved local key reference without authorizing its use."""
+    scheme, reference = _split_key_reference(key_ref)
+    available = tuple(resolvers) if resolvers is not None else (EnvironmentKeyResolver(), FileKeyResolver())
+    matches = tuple(resolver for resolver in available if resolver.scheme == scheme)
+    if not matches:
+        raise KeyResolutionError("unsupported_resolver", f"no resolver is configured for {scheme!r}", key_ref=key_ref)
+    if len(matches) != 1:
+        raise KeyResolutionError("ambiguous_key_reference", f"multiple resolvers are configured for {scheme!r}", key_ref=key_ref)
+    try:
+        material = matches[0].resolve(reference)
+    except KeyResolutionError:
+        raise
+    except Exception as exc:
+        raise KeyResolutionError("key_resolution_failed", "resolver failed without a classified error", key_ref=key_ref) from exc
+    if not isinstance(material, bytes) or not material:
+        raise KeyResolutionError("malformed_key_material", "resolved key material must be non-empty bytes", key_ref=key_ref)
+    return material
+
+
+def resolve_trust_policy_key(key: TrustPolicyKey, *, resolvers: Iterable[KeyResolver] | None = None) -> bytes:
+    """Resolve a parsed policy key record without checking policy state or authorization."""
+    return resolve_key_reference(key.key_ref, resolvers=resolvers)

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -95,9 +95,10 @@ class KeyResolverTests(unittest.TestCase):
 
     def test_fails_closed_for_unreadable_file(self):
         resolver = FileKeyResolver()
+        key_ref = f"file:{Path.cwd() / 'synthetic.key'}"
         with mock.patch("pathlib.Path.read_bytes", side_effect=PermissionError("denied")):
             with self.assertRaises(KeyResolutionError) as raised:
-                resolve_key_reference("file:/synthetic.key", resolvers=(resolver,))
+                resolve_key_reference(key_ref, resolvers=(resolver,))
         self.assertEqual(raised.exception.code, "key_reference_unreadable")
 
     def test_fails_closed_for_empty_or_non_byte_material(self):

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+from unittest import mock
+
+from repro_evidence_kit.key_resolver import (
+    EnvironmentKeyResolver,
+    FileKeyResolver,
+    KeyResolutionError,
+    resolve_key_reference,
+    resolve_trust_policy_key,
+)
+from repro_evidence_kit.trust_policy import parse_trust_policy
+
+
+def _parsed_key(key_ref: str):
+    policy = parse_trust_policy(
+        {
+            "policy_version": "1.0",
+            "policy_id": "synthetic-resolver-policy",
+            "keys": [
+                {
+                    "key_id": "synthetic-key",
+                    "algorithm": "hmac-sha256",
+                    "key_ref": key_ref,
+                    "state": "verify_only",
+                    "not_before": "2026-01-01T00:00:00Z",
+                }
+            ],
+        }
+    )
+    return policy.keys[0]
+
+
+class KeyResolverTests(unittest.TestCase):
+    def test_default_resolvers_use_the_current_environment_and_absolute_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            key_path = Path(td) / "synthetic.key"
+            key_path.write_bytes(b"synthetic-file-value")
+            with mock.patch.dict("os.environ", {"SYNTHETIC_KEY": "synthetic-env-value"}, clear=True):
+                self.assertEqual(resolve_key_reference("env:SYNTHETIC_KEY"), b"synthetic-env-value")
+                self.assertEqual(resolve_key_reference(f"file:{key_path}"), b"synthetic-file-value")
+
+    def test_resolves_synthetic_environment_material_exactly(self):
+        resolver = EnvironmentKeyResolver({"SYNTHETIC_KEY": "synthetic-value-\u2603"})
+
+        material = resolve_trust_policy_key(_parsed_key("env:SYNTHETIC_KEY"), resolvers=(resolver,))
+
+        self.assertEqual(material, "synthetic-value-\u2603".encode())
+
+    def test_resolves_synthetic_file_material_exactly(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "synthetic.key").write_bytes(b"synthetic-file-key\n")
+
+            material = resolve_key_reference("file:synthetic.key", resolvers=(FileKeyResolver(root),))
+
+        self.assertEqual(material, b"synthetic-file-key\n")
+
+    def test_fails_closed_for_missing_references(self):
+        with tempfile.TemporaryDirectory() as td:
+            cases = (
+                ("env:MISSING_KEY", (EnvironmentKeyResolver({}),)),
+                ("file:missing.key", (FileKeyResolver(Path(td)),)),
+            )
+            for key_ref, resolvers in cases:
+                with self.subTest(key_ref=key_ref), self.assertRaises(KeyResolutionError) as raised:
+                    resolve_key_reference(key_ref, resolvers=resolvers)
+                self.assertEqual(raised.exception.code, "key_reference_missing")
+                self.assertEqual(raised.exception.details[0]["key_ref"], key_ref)
+
+    def test_fails_closed_for_unsupported_invalid_and_ambiguous_references(self):
+        for key_ref, expected_code in (
+            ("https://example.test/key", "unsupported_resolver"),
+            ("ENV:SYNTHETIC_KEY", "unsupported_resolver"),
+            ("env:bad-name", "invalid_key_reference"),
+            ("file://remote/key", "invalid_key_reference"),
+        ):
+            with self.subTest(key_ref=key_ref), self.assertRaises(KeyResolutionError) as raised:
+                resolve_key_reference(key_ref)
+            self.assertEqual(raised.exception.code, expected_code)
+
+        duplicate = (EnvironmentKeyResolver({"SYNTHETIC_KEY": "a"}), EnvironmentKeyResolver({"SYNTHETIC_KEY": "b"}))
+        with self.assertRaises(KeyResolutionError) as raised:
+            resolve_key_reference("env:SYNTHETIC_KEY", resolvers=duplicate)
+        self.assertEqual(raised.exception.code, "ambiguous_key_reference")
+
+        with self.assertRaises(KeyResolutionError) as raised:
+            resolve_key_reference("file:relative.key", resolvers=(FileKeyResolver(),))
+        self.assertEqual(raised.exception.code, "ambiguous_key_reference")
+
+    def test_fails_closed_for_unreadable_file(self):
+        resolver = FileKeyResolver()
+        with mock.patch("pathlib.Path.read_bytes", side_effect=PermissionError("denied")):
+            with self.assertRaises(KeyResolutionError) as raised:
+                resolve_key_reference("file:/synthetic.key", resolvers=(resolver,))
+        self.assertEqual(raised.exception.code, "key_reference_unreadable")
+
+    def test_fails_closed_for_empty_or_non_byte_material(self):
+        @dataclass(frozen=True)
+        class SyntheticResolver:
+            values: Mapping[str, object]
+            scheme: str = "env"
+
+            def resolve(self, reference: str) -> bytes:
+                return self.values[reference]  # type: ignore[return-value]
+
+        for material in (b"", "not-bytes"):
+            with self.subTest(material=material), self.assertRaises(KeyResolutionError) as raised:
+                resolve_key_reference("env:SYNTHETIC_KEY", resolvers=(SyntheticResolver({"SYNTHETIC_KEY": material}),))
+            self.assertEqual(raised.exception.code, "malformed_key_material")
+
+        with tempfile.TemporaryDirectory() as td:
+            empty_path = Path(td) / "empty.key"
+            empty_path.write_bytes(b"")
+            empty_cases = (
+                ("env:SYNTHETIC_KEY", (EnvironmentKeyResolver({"SYNTHETIC_KEY": ""}),)),
+                (f"file:{empty_path}", (FileKeyResolver(),)),
+            )
+            for key_ref, resolvers in empty_cases:
+                with self.subTest(key_ref=key_ref), self.assertRaises(KeyResolutionError) as raised:
+                    resolve_key_reference(key_ref, resolvers=resolvers)
+                self.assertEqual(raised.exception.code, "malformed_key_material")
+
+    def test_classifies_unexpected_resolver_failure_without_leaking_values(self):
+        @dataclass(frozen=True)
+        class BrokenResolver:
+            scheme: str = "env"
+
+            def resolve(self, reference: str) -> bytes:
+                raise RuntimeError("synthetic-secret-value")
+
+        with self.assertRaises(KeyResolutionError) as raised:
+            resolve_key_reference("env:SYNTHETIC_KEY", resolvers=(BrokenResolver(),))
+        self.assertEqual(raised.exception.code, "key_resolution_failed")
+        self.assertNotIn("synthetic-secret-value", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add local `env:` and `file:` key resolver interfaces for issue #63
- return stable fail-closed `KeyResolutionError` categories for missing, unsupported, ambiguous, unreadable, and malformed inputs
- keep resolution separate from authorization, verification, signing, and signer-identity claims
- add synthetic fixtures and update the signer-trust roadmap/docs/changelog

## Why

Issue #63 is the resolver-only step between the policy parser (#62) and policy-aware verification (#64). Relative file references now require an explicit base directory instead of depending on process working directory.

## Validation

- `uv run pytest -q` — 93 passed, 18 subtests passed
- `uv run --extra schema pytest -q` — 93 passed, 18 subtests passed
- `uv run --extra dev coverage run -m unittest discover -s tests` — 93 passed
- `uv run --extra dev coverage report` — 89%
- `uv run ruff check src tests scripts`
- `uv run mypy src`
- `git diff --check`
- `python3 scripts/smoke_examples.py`
- `python3 scripts/release_install_smoke.py .`
- `python3 scripts/release_install_smoke.py '.[schema]'`

Closes #63.