### PR TITLE
Add policy-aware signature verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Add synthetic-only local `env:`/`file:` key resolver interfaces for issue #63
   with stable fail-closed errors. Resolution does not authorize policy state,
   sign, verify, or establish signer identity.
+- Add policy-aware signature verification for issue #64 with caller-selected
+  policy/key identity, fail-closed state and resolver checks, and stable result
+  categories. Sidecar `key_hint` remains advisory and signing is unchanged.
 
 ## 0.4.2 - 2026-06-13
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,9 +55,10 @@
 - Design signer trust, key rotation, and revocation policy in
   [issue #53](https://github.com/xodnr927-byte/repro-evidence-kit/issues/53)
   before expanding the signed-sidecar prototype. The policy parser and local
-  synthetic `env:`/`file:` resolver interfaces are documented in
-  [docs/signer-trust-policy.md](docs/signer-trust-policy.md); policy-aware
-  verification and signing remain separate follow-up work.
+  synthetic `env:`/`file:` resolver interfaces and caller-selected policy-aware
+  verification are documented in
+  [docs/signer-trust-policy.md](docs/signer-trust-policy.md). Policy-aware
+  signing remains separate follow-up work.
 
 ## Later ideas
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -121,6 +121,22 @@ repro-evidence evidence verify-signature examples/evidence-bundle.yaml \
   --key local-test.key
 ```
 
+Policy-aware verification requires both a caller-selected policy and expected
+key identity:
+
+```bash
+repro-evidence evidence verify-signature examples/evidence-bundle.yaml \
+  --signature examples/evidence-bundle.yaml.sig.json \
+  --trust-policy trust-policy.yaml \
+  --key-id expected-key
+```
+
+`--key` and `--trust-policy` are mutually exclusive. Policy mode never selects
+a key from the sidecar's advisory `key_hint` and never falls back to `--key`.
+Relative `file:` references are resolved from the policy file's directory.
+Trust or signature failures exit `1`; malformed policy and key-resolution
+infrastructure failures exit `2` with structured result codes.
+
 Use `--format text` for maintainer-friendly CI logs, or keep the default JSON for machine-readable output. JSON results include `errors` plus structured `error_details` with stable categories such as `payload_hash_mismatch`, `signature_mismatch`, `unsupported_signature_version`, `unsupported_algorithm`, `missing_signature`, and parse/read failures as exit code `2`.
 
 Use `--schema` to validate the sidecar shape against `schemas/signature-sidecar.schema.json` when the optional `jsonschema` dependency is installed.

--- a/docs/signer-trust-policy.md
+++ b/docs/signer-trust-policy.md
@@ -233,7 +233,9 @@ Implementation should remain split into independently reviewable work:
 3. Add resolver interfaces with synthetic environment/file fixtures. This is
    implemented by `repro_evidence_kit.key_resolver`; authorization, signing,
    and verification remain separate.
-4. Add policy-aware verification and stable structured error categories.
+4. Add policy-aware verification and stable structured error categories. This
+   is implemented by `repro_evidence_kit.policy_verification` and the
+   `verify-signature --trust-policy ... --key-id ...` CLI mode.
 5. Add policy-aware signing only after verification behavior is reviewed.
 
 Each implementation slice must retain synthetic-only fixtures and must not claim

--- a/scripts/release_install_smoke.py
+++ b/scripts/release_install_smoke.py
@@ -53,12 +53,49 @@ def main(argv: list[str] | None = None) -> int:
         bundle = root / "evidence-bundle.yaml"
         key = root / "local-test.key"
         signature = root / "evidence-bundle.yaml.sig.json"
+        policy = root / "trust-policy.yaml"
         bundle.write_text("schema_version: '1.0'\ntitle: Synthetic\ninputs: []\ncommands: []\noutputs: []\n", encoding="utf-8")
         key.write_text("synthetic local test key only\n", encoding="utf-8")
+        policy.write_text(
+            "policy_version: '1.0'\npolicy_id: release-smoke-policy\nkeys:\n"
+            "  - key_id: local-synthetic\n    algorithm: hmac-sha256\n"
+            f"    key_ref: file:{key.name}\n    state: verify_only\n"
+            "    not_before: '2026-01-01T00:00:00Z'\n",
+            encoding="utf-8",
+        )
         run([str(repro), "evidence", "sign", str(bundle), "--key", str(key), "--key-hint", "local-synthetic", "-o", str(signature)])
         run([str(repro), "evidence", "verify-signature", str(bundle), "--signature", str(signature), "--key", str(key)])
+        run(
+            [
+                str(repro),
+                "evidence",
+                "verify-signature",
+                str(bundle),
+                "--signature",
+                str(signature),
+                "--trust-policy",
+                str(policy),
+                "--key-id",
+                "local-synthetic",
+            ]
+        )
         bundle.write_text(bundle.read_text(encoding="utf-8") + "tamper: true\n", encoding="utf-8")
         run([str(repro), "evidence", "verify-signature", str(bundle), "--signature", str(signature), "--key", str(key)], expect=1)
+        run(
+            [
+                str(repro),
+                "evidence",
+                "verify-signature",
+                str(bundle),
+                "--signature",
+                str(signature),
+                "--trust-policy",
+                str(policy),
+                "--key-id",
+                "local-synthetic",
+            ],
+            expect=1,
+        )
 
     print("release/install smoke checks passed")
     return 0

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -7,7 +7,15 @@ from pathlib import Path
 from . import __version__
 from .evidence import evidence_result_as_junit, load_evidence, validate_evidence_bundle, validate_evidence_bundle_schema, validate_signature_sidecar_schema
 from .manifest import create_manifest, diff_manifests, load_manifest, write_json, write_text
+from .policy_verification import (
+    default_policy_resolvers,
+    policy_verification_exit_code,
+    selected_policy_key_file,
+    trust_policy_error_result,
+    verify_bundle_signature_with_policy,
+)
 from .signing import load_signature_sidecar, sign_bundle, signature_verification_as_text, verify_bundle_signature
+from .trust_policy import TrustPolicyError, load_trust_policy
 from .verify import sandbox_result_as_junit, sandbox_result_as_sarif, verify_sandbox_output
 
 
@@ -86,7 +94,10 @@ def build_parser() -> argparse.ArgumentParser:
     verify_sig = evidence_sub.add_parser("verify-signature", help="Verify an evidence bundle signature sidecar")
     verify_sig.add_argument("bundle", type=Path)
     verify_sig.add_argument("--signature", required=True, type=Path, help="Signature sidecar JSON")
-    verify_sig.add_argument("--key", required=True, type=Path, help="Local synthetic or trusted HMAC key file")
+    verification_key = verify_sig.add_mutually_exclusive_group(required=True)
+    verification_key.add_argument("--key", type=Path, help="Legacy local HMAC key file")
+    verification_key.add_argument("--trust-policy", type=Path, help="Local signer trust policy YAML/JSON")
+    verify_sig.add_argument("--key-id", help="Expected policy key identity selected by the caller")
     verify_sig.add_argument("--format", choices=("json", "text"), default="json")
     verify_sig.add_argument("--schema", action="store_true", help="Also validate the signature sidecar shape with schemas/signature-sidecar.schema.json")
     verify_sig.add_argument("--schema-path", type=Path, help="Use a custom JSON Schema path with --schema")
@@ -163,10 +174,36 @@ def main(argv: list[str] | None = None) -> int:
                 args.bundle,
                 args.signature,
                 args.key,
+                args.trust_policy,
                 args.schema_path,
             )
             sidecar = load_signature_sidecar(args.signature)
-            signature_result = verify_bundle_signature(args.bundle, sidecar, args.key)
+            if args.trust_policy is not None:
+                if args.key_id is None:
+                    raise ValueError("--trust-policy requires --key-id")
+                if not args.key_id or args.key_id != args.key_id.strip() or any(char.isspace() or ord(char) == 127 for char in args.key_id):
+                    raise ValueError("--key-id must be a non-empty identifier without whitespace or control characters")
+                try:
+                    policy = load_trust_policy(args.trust_policy)
+                except TrustPolicyError as exc:
+                    signature_result = trust_policy_error_result(sidecar, args.key_id, exc)
+                else:
+                    _ensure_output_does_not_overwrite_input(
+                        args.output,
+                        selected_policy_key_file(policy, args.key_id, args.trust_policy),
+                    )
+                    signature_result = verify_bundle_signature_with_policy(
+                        args.bundle,
+                        sidecar,
+                        policy,
+                        args.key_id,
+                        resolvers=default_policy_resolvers(args.trust_policy),
+                    )
+            else:
+                if args.key_id is not None:
+                    raise ValueError("--key-id requires --trust-policy")
+                assert args.key is not None
+                signature_result = verify_bundle_signature(args.bundle, sidecar, args.key)
             if args.schema:
                 schema_result = validate_signature_sidecar_schema(sidecar, args.schema_path)
                 signature_result["schema"] = schema_result
@@ -175,7 +212,7 @@ def main(argv: list[str] | None = None) -> int:
                 write_text(signature_verification_as_text(signature_result), args.output)
             else:
                 write_json(signature_result, args.output)
-            return 0 if signature_result["ok"] else 1
+            return policy_verification_exit_code(signature_result)
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/src/repro_evidence_kit/key_resolver.py
+++ b/src/repro_evidence_kit/key_resolver.py
@@ -25,7 +25,10 @@ class KeyResolutionError(ValueError):
 class KeyResolver(Protocol):
     """Interface for one local, parser-approved key-reference scheme."""
 
-    scheme: str
+    @property
+    def scheme(self) -> str:
+        """Resolver scheme claimed by this implementation."""
+        ...
 
     def resolve(self, reference: str) -> bytes:
         """Return the exact key bytes for the scheme-specific reference."""

--- a/src/repro_evidence_kit/policy_verification.py
+++ b/src/repro_evidence_kit/policy_verification.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from .key_resolver import EnvironmentKeyResolver, FileKeyResolver, KeyResolutionError, KeyResolver, resolve_trust_policy_key
+from .signing import verify_bundle_signature_with_key
+from .trust_policy import TrustPolicy, TrustPolicyError
+
+
+POLICY_ERROR_MESSAGES = {
+    "unknown_key_id": "expected key_id is not present in the trust policy",
+    "key_not_active": "policy key is not active yet",
+    "key_revoked": "policy key is revoked",
+    "policy_algorithm_mismatch": "sidecar algorithm does not match the selected policy key",
+    "key_resolution_failed": "policy key reference could not be resolved",
+    "policy_invalid": "trust policy is invalid",
+    "policy_parse_error": "trust policy could not be parsed",
+}
+
+
+def _policy_result(
+    sidecar: dict[str, Any],
+    policy: TrustPolicy,
+    key_id: str,
+    *,
+    code: str,
+    field: str,
+    failure_class: str = "trust",
+    state: str | None = None,
+    expected: Any = None,
+    actual: Any = None,
+    cause_code: str | None = None,
+) -> dict[str, Any]:
+    detail: dict[str, Any] = {"code": code, "field": field, "message": POLICY_ERROR_MESSAGES[code]}
+    if expected is not None:
+        detail["expected"] = expected
+    if actual is not None:
+        detail["actual"] = actual
+    if cause_code is not None:
+        detail["cause_code"] = cause_code
+    return {
+        "ok": False,
+        "errors": [POLICY_ERROR_MESSAGES[code]],
+        "error_details": [detail],
+        "failure_class": failure_class,
+        "algorithm": sidecar.get("algorithm"),
+        "payload_path": sidecar.get("payload_path"),
+        "key_hint": sidecar.get("key_hint"),
+        "policy_id": policy.policy_id,
+        "key_id": key_id,
+        "policy_state": state,
+        "policy_key_allowed_for_verification": False,
+    }
+
+
+def trust_policy_error_result(sidecar: dict[str, Any], key_id: str, error: TrustPolicyError) -> dict[str, Any]:
+    """Render a parser failure without falling back to a sidecar hint or legacy key."""
+    code = error.code if error.code in POLICY_ERROR_MESSAGES else "policy_invalid"
+    detail = {
+        "code": code,
+        "field": "trust_policy",
+        "message": POLICY_ERROR_MESSAGES[code],
+        "policy_details": list(error.details),
+    }
+    return {
+        "ok": False,
+        "errors": [POLICY_ERROR_MESSAGES[code]],
+        "error_details": [detail],
+        "failure_class": "infrastructure",
+        "algorithm": sidecar.get("algorithm"),
+        "payload_path": sidecar.get("payload_path"),
+        "key_hint": sidecar.get("key_hint"),
+        "policy_id": None,
+        "key_id": key_id,
+        "policy_state": None,
+        "policy_key_allowed_for_verification": False,
+    }
+
+
+def verify_bundle_signature_with_policy(
+    bundle_path: Path,
+    sidecar: dict[str, Any],
+    policy: TrustPolicy,
+    key_id: str,
+    *,
+    resolvers: Iterable[KeyResolver] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Authorize one caller-selected policy key, then verify exact version 1 bundle bytes."""
+    selected = policy.key_by_id(key_id)
+    if selected is None:
+        return _policy_result(sidecar, policy, key_id, code="unknown_key_id", field="key_id", actual=key_id)
+    if selected.state == "revoked":
+        return _policy_result(sidecar, policy, key_id, code="key_revoked", field="state", state=selected.state, actual=selected.state)
+
+    current_time = now or datetime.now(timezone.utc)
+    if current_time.tzinfo is None or current_time.utcoffset() is None:
+        raise ValueError("policy verification time must include a timezone")
+    current_time = current_time.astimezone(timezone.utc)
+    if current_time < selected.not_before:
+        return _policy_result(
+            sidecar,
+            policy,
+            key_id,
+            code="key_not_active",
+            field="not_before",
+            state=selected.state,
+            expected=f"at or after {selected.not_before.isoformat()}",
+            actual=current_time.isoformat(),
+        )
+    if sidecar.get("algorithm") != selected.algorithm:
+        return _policy_result(
+            sidecar,
+            policy,
+            key_id,
+            code="policy_algorithm_mismatch",
+            field="algorithm",
+            state=selected.state,
+            expected=selected.algorithm,
+            actual=sidecar.get("algorithm"),
+        )
+
+    try:
+        key = resolve_trust_policy_key(selected, resolvers=resolvers)
+    except KeyResolutionError as exc:
+        return _policy_result(
+            sidecar,
+            policy,
+            key_id,
+            code="key_resolution_failed",
+            field="key_ref",
+            failure_class="infrastructure",
+            state=selected.state,
+            cause_code=exc.code,
+        )
+
+    result = verify_bundle_signature_with_key(bundle_path, sidecar, key)
+    result.update(
+        {
+            "policy_id": policy.policy_id,
+            "key_id": key_id,
+            "policy_state": selected.state,
+            "policy_key_allowed_for_verification": True,
+        }
+    )
+    if not result["ok"]:
+        result["failure_class"] = "verification"
+    return result
+
+
+def default_policy_resolvers(policy_path: Path) -> tuple[KeyResolver, ...]:
+    """Bind relative file references to the selected policy's directory."""
+    return (EnvironmentKeyResolver(), FileKeyResolver(policy_path.parent.resolve()))
+
+
+def selected_policy_key_file(policy: TrustPolicy, key_id: str, policy_path: Path) -> Path | None:
+    """Return the selected local file reference for output-overwrite protection."""
+    selected = policy.key_by_id(key_id)
+    if selected is None:
+        return None
+    scheme, _, reference = selected.key_ref.partition(":")
+    if scheme != "file":
+        return None
+    path = Path(reference)
+    return path if path.is_absolute() else policy_path.parent.resolve() / path
+
+
+def policy_verification_exit_code(result: dict[str, Any]) -> int:
+    if result.get("ok"):
+        return 0
+    return 2 if result.get("failure_class") == "infrastructure" else 1

--- a/src/repro_evidence_kit/signing.py
+++ b/src/repro_evidence_kit/signing.py
@@ -5,7 +5,7 @@ import hmac
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 SIGNATURE_VERSION = "1.0"
 ALGORITHM = "hmac-sha256"
@@ -70,6 +70,17 @@ def _append_error(errors: list[str], details: list[dict[str, Any]], code: str, *
 
 
 def verify_bundle_signature(bundle_path: Path, sidecar: dict[str, Any], key_path: Path) -> dict[str, Any]:
+    return _verify_bundle_signature(bundle_path, sidecar, lambda: load_key(key_path))
+
+
+def verify_bundle_signature_with_key(bundle_path: Path, sidecar: dict[str, Any], key: bytes) -> dict[str, Any]:
+    """Verify exact bundle bytes with already-resolved non-empty key material."""
+    if not key:
+        raise ValueError("verification key is empty")
+    return _verify_bundle_signature(bundle_path, sidecar, lambda: key)
+
+
+def _verify_bundle_signature(bundle_path: Path, sidecar: dict[str, Any], load_verification_key: Callable[[], bytes]) -> dict[str, Any]:
     errors: list[str] = []
     details: list[dict[str, Any]] = []
     if sidecar.get("signature_version") != SIGNATURE_VERSION:
@@ -104,7 +115,7 @@ def verify_bundle_signature(bundle_path: Path, sidecar: dict[str, Any], key_path
     elif not _HEX64.match(signature):
         _append_error(errors, details, "invalid_signature", field="signature", expected="64 lowercase hex characters", actual=signature)
     else:
-        expected = hmac.new(load_key(key_path), payload, hashlib.sha256).hexdigest()
+        expected = hmac.new(load_verification_key(), payload, hashlib.sha256).hexdigest()
         if not hmac.compare_digest(signature, expected):
             _append_error(errors, details, "signature_mismatch", field="signature", expected=expected, actual=signature)
 
@@ -125,6 +136,12 @@ def signature_verification_as_text(result: dict[str, Any]) -> str:
         lines.append(f"algorithm: {result['algorithm']}")
     if result.get("key_hint"):
         lines.append(f"key_hint: {result['key_hint']}")
+    if result.get("policy_id"):
+        lines.append(f"policy_id: {result['policy_id']}")
+    if result.get("key_id"):
+        lines.append(f"key_id: {result['key_id']}")
+    if result.get("policy_state"):
+        lines.append(f"policy_state: {result['policy_state']}")
     if result.get("payload_path"):
         lines.append(f"payload_path: {result['payload_path']}")
     if result.get("payload_sha256"):

--- a/tests/test_policy_verification.py
+++ b/tests/test_policy_verification.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from repro_evidence_kit.cli import main
+from repro_evidence_kit.key_resolver import EnvironmentKeyResolver
+from repro_evidence_kit.policy_verification import policy_verification_exit_code, verify_bundle_signature_with_policy
+from repro_evidence_kit.signing import sign_bundle
+from repro_evidence_kit.trust_policy import parse_trust_policy
+
+
+NOW = datetime(2026, 7, 16, tzinfo=timezone.utc)
+
+
+def _policy(*, key_ref: str = "env:SYNTHETIC_KEY", state: str = "verify_only", not_before: str = "2026-01-01T00:00:00Z"):
+    return parse_trust_policy(
+        {
+            "policy_version": "1.0",
+            "policy_id": "synthetic-verification-policy",
+            "keys": [
+                {
+                    "key_id": "expected-key",
+                    "algorithm": "hmac-sha256",
+                    "key_ref": key_ref,
+                    "state": state,
+                    "not_before": not_before,
+                }
+            ],
+        }
+    )
+
+
+class PolicyVerificationTests(unittest.TestCase):
+    def _sidecar(self, root: Path, *, key_hint: str = "attacker-controlled-hint"):
+        bundle = root / "bundle.yaml"
+        key = root / "signing.key"
+        bundle.write_text("title: Synthetic\n", encoding="utf-8")
+        key.write_bytes(b"synthetic-policy-key")
+        return bundle, sign_bundle(bundle, key, key_hint=key_hint)
+
+    def test_active_and_verify_only_keys_verify_with_caller_selected_identity(self):
+        with tempfile.TemporaryDirectory() as td:
+            bundle, sidecar = self._sidecar(Path(td))
+            resolver = EnvironmentKeyResolver({"SYNTHETIC_KEY": "synthetic-policy-key"})
+            for state in ("active", "verify_only"):
+                with self.subTest(state=state):
+                    result = verify_bundle_signature_with_policy(
+                        bundle,
+                        sidecar,
+                        _policy(state=state),
+                        "expected-key",
+                        resolvers=(resolver,),
+                        now=NOW,
+                    )
+                    self.assertTrue(result["ok"])
+                    self.assertEqual(result["key_id"], "expected-key")
+                    self.assertEqual(result["key_hint"], "attacker-controlled-hint")
+                    self.assertTrue(result["policy_key_allowed_for_verification"])
+                    self.assertEqual(policy_verification_exit_code(result), 0)
+
+    def test_unknown_key_id_does_not_fall_back_to_key_hint_or_resolve(self):
+        with tempfile.TemporaryDirectory() as td:
+            bundle, sidecar = self._sidecar(Path(td), key_hint="expected-key")
+            result = verify_bundle_signature_with_policy(
+                bundle,
+                sidecar,
+                _policy(),
+                "missing-key",
+                resolvers=(EnvironmentKeyResolver({}),),
+                now=NOW,
+            )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_details"][0]["code"], "unknown_key_id")
+        self.assertEqual(policy_verification_exit_code(result), 1)
+
+    def test_revoked_and_not_yet_active_keys_fail_before_resolution(self):
+        with tempfile.TemporaryDirectory() as td:
+            bundle, sidecar = self._sidecar(Path(td))
+            cases = (
+                (_policy(state="revoked"), "key_revoked"),
+                (_policy(not_before="2026-08-01T00:00:00Z"), "key_not_active"),
+            )
+            for policy, expected_code in cases:
+                with self.subTest(expected_code=expected_code):
+                    result = verify_bundle_signature_with_policy(
+                        bundle,
+                        sidecar,
+                        policy,
+                        "expected-key",
+                        resolvers=(EnvironmentKeyResolver({}),),
+                        now=NOW,
+                    )
+                    self.assertEqual(result["error_details"][0]["code"], expected_code)
+                    self.assertFalse(result["policy_key_allowed_for_verification"])
+
+    def test_algorithm_mismatch_fails_before_resolution(self):
+        with tempfile.TemporaryDirectory() as td:
+            bundle, sidecar = self._sidecar(Path(td))
+            sidecar["algorithm"] = "unknown"
+            result = verify_bundle_signature_with_policy(
+                bundle,
+                sidecar,
+                _policy(),
+                "expected-key",
+                resolvers=(EnvironmentKeyResolver({}),),
+                now=NOW,
+            )
+
+        self.assertEqual(result["error_details"][0]["code"], "policy_algorithm_mismatch")
+
+    def test_resolution_failure_is_structured_infrastructure_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            bundle, sidecar = self._sidecar(Path(td))
+            result = verify_bundle_signature_with_policy(
+                bundle,
+                sidecar,
+                _policy(),
+                "expected-key",
+                resolvers=(EnvironmentKeyResolver({}),),
+                now=NOW,
+            )
+
+        detail = result["error_details"][0]
+        self.assertEqual(detail["code"], "key_resolution_failed")
+        self.assertEqual(detail["cause_code"], "key_reference_missing")
+        self.assertEqual(policy_verification_exit_code(result), 2)
+
+    def test_signature_mismatch_remains_a_verification_failure(self):
+        with tempfile.TemporaryDirectory() as td:
+            bundle, sidecar = self._sidecar(Path(td))
+            result = verify_bundle_signature_with_policy(
+                bundle,
+                sidecar,
+                _policy(),
+                "expected-key",
+                resolvers=(EnvironmentKeyResolver({"SYNTHETIC_KEY": "wrong-synthetic-key"}),),
+                now=NOW,
+            )
+
+        self.assertEqual(result["failure_class"], "verification")
+        self.assertIn("signature_mismatch", {detail["code"] for detail in result["error_details"]})
+        self.assertEqual(policy_verification_exit_code(result), 1)
+
+
+class PolicyVerificationCliTests(unittest.TestCase):
+    def _write_fixture(self, root: Path, *, state: str = "verify_only") -> tuple[Path, Path, Path, Path]:
+        bundle = root / "bundle.yaml"
+        key = root / "synthetic.key"
+        signature = root / "bundle.yaml.sig.json"
+        policy = root / "trust-policy.yaml"
+        bundle.write_text("title: Synthetic\n", encoding="utf-8")
+        key.write_bytes(b"synthetic-policy-key")
+        signature.write_text(json.dumps(sign_bundle(bundle, key, key_hint="untrusted-hint")), encoding="utf-8")
+        policy.write_text(
+            "policy_version: '1.0'\npolicy_id: synthetic-cli-policy\nkeys:\n"
+            "  - key_id: expected-key\n    algorithm: hmac-sha256\n"
+            f"    key_ref: file:{key.name}\n    state: {state}\n"
+            "    not_before: '2026-01-01T00:00:00Z'\n",
+            encoding="utf-8",
+        )
+        return bundle, key, signature, policy
+
+    def test_cli_verifies_relative_file_reference_from_policy_directory(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, _, signature, policy = self._write_fixture(root)
+            output = root / "result.json"
+            code = main(
+                [
+                    "evidence",
+                    "verify-signature",
+                    str(bundle),
+                    "--signature",
+                    str(signature),
+                    "--trust-policy",
+                    str(policy),
+                    "--key-id",
+                    "expected-key",
+                    "-o",
+                    str(output),
+                ]
+            )
+            result = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(code, 0)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["policy_id"], "synthetic-cli-policy")
+
+    def test_cli_returns_1_for_revoked_key(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, _, signature, policy = self._write_fixture(root, state="revoked")
+            output = root / "result.json"
+            code = main(
+                [
+                    "evidence",
+                    "verify-signature",
+                    str(bundle),
+                    "--signature",
+                    str(signature),
+                    "--trust-policy",
+                    str(policy),
+                    "--key-id",
+                    "expected-key",
+                    "-o",
+                    str(output),
+                ]
+            )
+            result = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(code, 1)
+        self.assertEqual(result["error_details"][0]["code"], "key_revoked")
+
+    def test_cli_returns_structured_exit_2_for_invalid_policy(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, _, signature, policy = self._write_fixture(root)
+            policy.write_text("policy_version: [broken\n", encoding="utf-8")
+            output = root / "result.json"
+            code = main(
+                [
+                    "evidence",
+                    "verify-signature",
+                    str(bundle),
+                    "--signature",
+                    str(signature),
+                    "--trust-policy",
+                    str(policy),
+                    "--key-id",
+                    "expected-key",
+                    "-o",
+                    str(output),
+                ]
+            )
+            result = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(code, 2)
+        self.assertEqual(result["error_details"][0]["code"], "policy_parse_error")
+
+    def test_cli_returns_structured_exit_2_for_missing_key_reference(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, key, signature, policy = self._write_fixture(root)
+            key.unlink()
+            output = root / "result.json"
+            code = main(
+                [
+                    "evidence",
+                    "verify-signature",
+                    str(bundle),
+                    "--signature",
+                    str(signature),
+                    "--trust-policy",
+                    str(policy),
+                    "--key-id",
+                    "expected-key",
+                    "-o",
+                    str(output),
+                ]
+            )
+            result = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(code, 2)
+        self.assertEqual(result["error_details"][0]["code"], "key_resolution_failed")
+        self.assertEqual(result["error_details"][0]["cause_code"], "key_reference_missing")
+
+    def test_cli_requires_key_id_only_for_policy_mode(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, key, signature, policy = self._write_fixture(root)
+            commands = (
+                ["evidence", "verify-signature", str(bundle), "--signature", str(signature), "--trust-policy", str(policy)],
+                ["evidence", "verify-signature", str(bundle), "--signature", str(signature), "--trust-policy", str(policy), "--key-id", ""],
+                ["evidence", "verify-signature", str(bundle), "--signature", str(signature), "--key", str(key), "--key-id", "expected-key"],
+            )
+            for command in commands:
+                with self.subTest(command=command), contextlib.redirect_stderr(io.StringIO()) as stderr:
+                    self.assertEqual(main(command), 2)
+                    self.assertIn("error:", stderr.getvalue())
+
+    def test_cli_does_not_overwrite_selected_policy_key(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, key, signature, policy = self._write_fixture(root)
+            before = key.read_bytes()
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                code = main(
+                    [
+                        "evidence",
+                        "verify-signature",
+                        str(bundle),
+                        "--signature",
+                        str(signature),
+                        "--trust-policy",
+                        str(policy),
+                        "--key-id",
+                        "expected-key",
+                        "-o",
+                        str(key),
+                    ]
+                )
+
+            self.assertEqual(code, 2)
+            self.assertIn("must not overwrite", stderr.getvalue())
+            self.assertEqual(key.read_bytes(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -89,6 +89,17 @@ class SigningTests(unittest.TestCase):
         self.assertIn("missing signature", result["errors"])
         self.assertEqual(result["error_details"][-1]["code"], "missing_signature")
 
+    def test_missing_signature_does_not_read_legacy_key(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle = root / "evidence-bundle.yaml"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+
+            result = verify_bundle_signature(bundle, {"signature_version": "1.0", "algorithm": "hmac-sha256"}, root / "missing.key")
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_details"][-1]["code"], "missing_signature")
+
     def test_verify_rejects_invalid_payload_hash_shape(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
## What changed

- add caller-selected policy-aware verification for issue #64
- require `--trust-policy` with `--key-id`, mutually exclusive with the legacy `--key` mode
- reject unknown, revoked, not-yet-active, and algorithm-mismatched policy keys before key resolution or HMAC verification
- return stable trust, verification, policy-parse, and key-resolution result categories with exit codes 0/1/2
- keep sidecar `key_hint` advisory and preserve version 1 sidecar and legacy verification behavior
- bind relative `file:` references to the selected policy directory and prevent result output from overwriting the selected key file
- exercise policy verification through fresh-install smoke tests

## Boundary

This PR does not add policy-aware signing, public identity, certificate authorities, remote key services, transparency logs, trusted signing time, revocation grandfathering, or artifact correctness claims.

## Validation

- `uv run pytest -q` — 106 passed, 25 subtests passed
- `uv run --extra schema pytest -q` — 106 passed, 25 subtests passed
- `uv run --extra dev coverage run -m unittest discover -s tests` — 106 passed
- `uv run --extra dev coverage report` — 89%
- `uv run ruff check src tests scripts`
- `uv run mypy src`
- `git diff --check`
- `python3 scripts/smoke_examples.py`
- `python3 scripts/release_install_smoke.py .`
- `python3 scripts/release_install_smoke.py '.[schema]'`

Closes #64.