### PR TITLE
Add policy-aware signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Add policy-aware signature verification for issue #64 with caller-selected
   policy/key identity, fail-closed state and resolver checks, and stable result
   categories. Sidecar `key_hint` remains advisory and signing is unchanged.
+- Add policy-aware signing for issue #65 with caller-selected policy/key
+  identity, active-only authorization, local key resolution, stable failure
+  codes, and unchanged version 1 sidecars. `key_hint` remains advisory.
 
 ## 0.4.2 - 2026-06-13
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,7 +58,8 @@
   synthetic `env:`/`file:` resolver interfaces and caller-selected policy-aware
   verification are documented in
   [docs/signer-trust-policy.md](docs/signer-trust-policy.md). Policy-aware
-  signing remains separate follow-up work.
+  signing now permits only caller-selected `active` keys while preserving the
+  version 1 sidecar boundary.
 
 ## Later ideas
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -111,6 +111,23 @@ repro-evidence evidence sign examples/evidence-bundle.yaml \
 
 The key file is local trust material. Do not commit live secrets or real maintainer private keys. The prototype algorithm is `hmac-sha256`, intended for local tamper detection and synthetic examples. Use `--dry-run` to print the sidecar that would be written without creating an output file.
 
+Policy-aware signing requires a caller-selected trust policy and key identity:
+
+```bash
+repro-evidence evidence sign examples/evidence-bundle.yaml \
+  --trust-policy trust-policy.yaml \
+  --key-id expected-key \
+  -o examples/evidence-bundle.yaml.sig.json
+```
+
+`--key` and `--trust-policy` are mutually exclusive. Policy mode permits only
+an `active` key whose `not_before` time has passed; `verify_only`, `revoked`,
+unknown, and not-yet-active keys fail before key resolution. Relative `file:`
+references resolve from the policy directory. The version 1 sidecar stays
+unchanged, and `key_hint` remains advisory metadata rather than authorization
+or public identity proof. Trust failures exit `1`; policy parse and key
+resolution failures exit `2` with stable error codes on stderr.
+
 ## `evidence verify-signature`
 
 Verify that a sidecar signature still matches the exact evidence bundle bytes and local key.

--- a/docs/signed-bundles.md
+++ b/docs/signed-bundles.md
@@ -94,6 +94,10 @@ See `examples/signed-bundle/README.md` for a minimal synthetic workflow.
 For the proposed caller-selected signer policy, key rotation, revocation
 semantics, and version 1 compatibility boundary, see
 [Signer trust, rotation, and revocation policy](signer-trust-policy.md).
+Policy-aware signing is available through `evidence sign` with
+`--trust-policy ... --key-id ...`; it resolves only a caller-selected `active`
+policy key and does not change the version 1 sidecar or elevate `key_hint` into
+authorization.
 
 ## Test fixture policy
 

--- a/docs/signer-trust-policy.md
+++ b/docs/signer-trust-policy.md
@@ -131,8 +131,11 @@ The verifier must not choose a key from `key_hint`, try every configured key
 until one succeeds, or treat a matching hint as authorization. Those behaviors
 would move signer selection into attacker-controlled input.
 
-Signing should require an `active` key. Verification may use `active` or
-`verify_only`; it must reject `revoked`.
+Signing requires an `active` key selected by the caller through
+`evidence sign --trust-policy ... --key-id ...`. Verification may use `active`
+or `verify_only`; both operations reject `revoked`. Policy-aware signing keeps
+the version 1 sidecar unchanged and uses `key_id` only as the default advisory
+`key_hint`; authorization is completed before that sidecar is created.
 
 ## Local key resolvers
 
@@ -236,7 +239,10 @@ Implementation should remain split into independently reviewable work:
 4. Add policy-aware verification and stable structured error categories. This
    is implemented by `repro_evidence_kit.policy_verification` and the
    `verify-signature --trust-policy ... --key-id ...` CLI mode.
-5. Add policy-aware signing only after verification behavior is reviewed.
+5. Add policy-aware signing only after verification behavior is reviewed. This
+   is implemented by `repro_evidence_kit.policy_signing` and the
+   `evidence sign --trust-policy ... --key-id ...` CLI mode; only `active` keys
+   can sign.
 
 Each implementation slice must retain synthetic-only fixtures and must not claim
 signer identity, artifact correctness, or trusted signing time.

--- a/src/repro_evidence_kit/cli.py
+++ b/src/repro_evidence_kit/cli.py
@@ -14,6 +14,7 @@ from .policy_verification import (
     trust_policy_error_result,
     verify_bundle_signature_with_policy,
 )
+from .policy_signing import PolicySigningError, policy_signing_exit_code, sign_bundle_with_policy
 from .signing import load_signature_sidecar, sign_bundle, signature_verification_as_text, verify_bundle_signature
 from .trust_policy import TrustPolicyError, load_trust_policy
 from .verify import sandbox_result_as_junit, sandbox_result_as_sarif, verify_sandbox_output
@@ -86,7 +87,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     sign = evidence_sub.add_parser("sign", help="Sign exact evidence bundle bytes with a local key")
     sign.add_argument("bundle", type=Path)
-    sign.add_argument("--key", required=True, type=Path, help="Local synthetic or trusted HMAC key file")
+    signing_key = sign.add_mutually_exclusive_group(required=True)
+    signing_key.add_argument("--key", type=Path, help="Legacy local HMAC key file")
+    signing_key.add_argument("--trust-policy", type=Path, help="Local signer trust policy YAML/JSON")
+    sign.add_argument("--key-id", help="Policy key identity selected by the caller")
     sign.add_argument("--key-hint", help="Non-secret key identifier to record in the sidecar")
     sign.add_argument("-o", "--output", type=Path)
     sign.add_argument("--dry-run", action="store_true", help="Print the sidecar that would be written without creating an output file")
@@ -158,14 +162,35 @@ def main(argv: list[str] | None = None) -> int:
                 write_json(evidence_result, args.output)
             return 0 if evidence_result["ok"] else 1
         if args.command == "evidence" and args.evidence_command == "sign":
-            if args.dry_run:
+            if args.output is None:
+                if not args.dry_run:
+                    raise ValueError("evidence sign requires -o/--output unless --dry-run is used")
+            _ensure_output_does_not_overwrite_input(args.output, args.bundle, args.key, args.trust_policy)
+            if args.trust_policy is not None:
+                if args.key_id is None:
+                    raise ValueError("--trust-policy requires --key-id")
+                if not args.key_id or args.key_id != args.key_id.strip() or any(char.isspace() or ord(char) == 127 for char in args.key_id):
+                    raise ValueError("--key-id must be a non-empty identifier without whitespace or control characters")
+                policy = load_trust_policy(args.trust_policy)
+                _ensure_output_does_not_overwrite_input(
+                    args.output,
+                    selected_policy_key_file(policy, args.key_id, args.trust_policy),
+                )
+                sidecar = sign_bundle_with_policy(
+                    args.bundle,
+                    policy,
+                    args.key_id,
+                    key_hint=args.key_hint,
+                    resolvers=default_policy_resolvers(args.trust_policy),
+                )
+            else:
+                if args.key_id is not None:
+                    raise ValueError("--key-id requires --trust-policy")
+                assert args.key is not None
                 sidecar = sign_bundle(args.bundle, args.key, key_hint=args.key_hint)
+            if args.dry_run:
                 write_json(sidecar, None)
                 return 0
-            if args.output is None:
-                raise ValueError("evidence sign requires -o/--output unless --dry-run is used")
-            _ensure_output_does_not_overwrite_input(args.output, args.bundle, args.key)
-            sidecar = sign_bundle(args.bundle, args.key, key_hint=args.key_hint)
             write_json(sidecar, args.output)
             return 0
         if args.command == "evidence" and args.evidence_command == "verify-signature":
@@ -213,6 +238,13 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 write_json(signature_result, args.output)
             return policy_verification_exit_code(signature_result)
+    except PolicySigningError as exc:
+        cause = f" (cause: {exc.cause_code})" if exc.cause_code else ""
+        print(f"error: {exc}{cause}", file=sys.stderr)
+        return policy_signing_exit_code(exc)
+    except TrustPolicyError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/src/repro_evidence_kit/policy_signing.py
+++ b/src/repro_evidence_kit/policy_signing.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from .key_resolver import KeyResolutionError, KeyResolver, resolve_trust_policy_key
+from .signing import ALGORITHM, sign_bundle_with_key
+from .trust_policy import TrustPolicy
+
+
+POLICY_SIGNING_ERROR_MESSAGES = {
+    "unknown_key_id": "selected key_id is not present in the trust policy",
+    "key_not_active": "policy key is not active yet",
+    "key_not_allowed_for_signing": "policy key state does not permit signing",
+    "key_revoked": "policy key is revoked",
+    "policy_algorithm_mismatch": "policy key algorithm is not supported for signing",
+    "key_resolution_failed": "policy key reference could not be resolved",
+}
+
+
+class PolicySigningError(ValueError):
+    """Fail-closed policy authorization or key-resolution error."""
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        policy_id: str,
+        key_id: str,
+        state: str | None = None,
+        failure_class: str = "trust",
+        cause_code: str | None = None,
+    ) -> None:
+        self.code = code
+        self.policy_id = policy_id
+        self.key_id = key_id
+        self.state = state
+        self.failure_class = failure_class
+        self.cause_code = cause_code
+        super().__init__(f"{code}: {POLICY_SIGNING_ERROR_MESSAGES[code]}")
+
+
+def sign_bundle_with_policy(
+    bundle_path: Path,
+    policy: TrustPolicy,
+    key_id: str,
+    *,
+    key_hint: str | None = None,
+    resolvers: Iterable[KeyResolver] | None = None,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Authorize one caller-selected active policy key, then create a version 1 sidecar."""
+    selected = policy.key_by_id(key_id)
+    if selected is None:
+        raise PolicySigningError("unknown_key_id", policy_id=policy.policy_id, key_id=key_id)
+    if selected.state == "revoked":
+        raise PolicySigningError("key_revoked", policy_id=policy.policy_id, key_id=key_id, state=selected.state)
+    if selected.state != "active":
+        raise PolicySigningError("key_not_allowed_for_signing", policy_id=policy.policy_id, key_id=key_id, state=selected.state)
+
+    current_time = now or datetime.now(timezone.utc)
+    if current_time.tzinfo is None or current_time.utcoffset() is None:
+        raise ValueError("policy signing time must include a timezone")
+    current_time = current_time.astimezone(timezone.utc)
+    if current_time < selected.not_before:
+        raise PolicySigningError("key_not_active", policy_id=policy.policy_id, key_id=key_id, state=selected.state)
+    if selected.algorithm != ALGORITHM:
+        raise PolicySigningError("policy_algorithm_mismatch", policy_id=policy.policy_id, key_id=key_id, state=selected.state)
+
+    try:
+        key = resolve_trust_policy_key(selected, resolvers=resolvers)
+    except KeyResolutionError as exc:
+        raise PolicySigningError(
+            "key_resolution_failed",
+            policy_id=policy.policy_id,
+            key_id=key_id,
+            state=selected.state,
+            failure_class="infrastructure",
+            cause_code=exc.code,
+        ) from exc
+    return sign_bundle_with_key(bundle_path, key, key_hint=key_hint or key_id)
+
+
+def policy_signing_exit_code(error: PolicySigningError) -> int:
+    return 2 if error.failure_class == "infrastructure" else 1

--- a/src/repro_evidence_kit/signing.py
+++ b/src/repro_evidence_kit/signing.py
@@ -42,15 +42,22 @@ def load_signature_sidecar(path: Path) -> dict[str, Any]:
 
 
 def sign_bundle(bundle_path: Path, key_path: Path, *, key_hint: str | None = None) -> dict[str, Any]:
-    payload = bundle_path.read_bytes()
     key = load_key(key_path)
+    return sign_bundle_with_key(bundle_path, key, key_hint=key_hint or key_path.name)
+
+
+def sign_bundle_with_key(bundle_path: Path, key: bytes, *, key_hint: str) -> dict[str, Any]:
+    """Sign exact bundle bytes with already-resolved non-empty key material."""
+    if not key:
+        raise ValueError("signing key is empty")
+    payload = bundle_path.read_bytes()
     signature = hmac.new(key, payload, hashlib.sha256).hexdigest()
     return {
         "signature_version": SIGNATURE_VERSION,
         "payload_path": bundle_path.name,
         "payload_sha256": sha256_bytes(payload),
         "algorithm": ALGORITHM,
-        "key_hint": key_hint or key_path.name,
+        "key_hint": key_hint,
         "signature": signature,
     }
 

--- a/tests/test_policy_signing.py
+++ b/tests/test_policy_signing.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from repro_evidence_kit.cli import main
+from repro_evidence_kit.key_resolver import EnvironmentKeyResolver
+from repro_evidence_kit.policy_signing import PolicySigningError, policy_signing_exit_code, sign_bundle_with_policy
+from repro_evidence_kit.policy_verification import verify_bundle_signature_with_policy
+from repro_evidence_kit.trust_policy import parse_trust_policy
+
+
+NOW = datetime(2026, 7, 18, tzinfo=timezone.utc)
+
+
+def _policy(*, key_ref: str = "env:SYNTHETIC_KEY", state: str = "active", not_before: str = "2026-01-01T00:00:00Z"):
+    return parse_trust_policy(
+        {
+            "policy_version": "1.0",
+            "policy_id": "synthetic-signing-policy",
+            "keys": [
+                {
+                    "key_id": "expected-key",
+                    "algorithm": "hmac-sha256",
+                    "key_ref": key_ref,
+                    "state": state,
+                    "not_before": not_before,
+                }
+            ],
+        }
+    )
+
+
+class PolicySigningTests(unittest.TestCase):
+    def test_active_key_signs_version_1_sidecar_and_policy_verification_accepts_it(self):
+        with tempfile.TemporaryDirectory() as td:
+            bundle = Path(td) / "bundle.yaml"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            resolver = EnvironmentKeyResolver({"SYNTHETIC_KEY": "synthetic-policy-key"})
+            policy = _policy()
+
+            sidecar = sign_bundle_with_policy(bundle, policy, "expected-key", resolvers=(resolver,), now=NOW)
+            result = verify_bundle_signature_with_policy(
+                bundle,
+                sidecar,
+                policy,
+                "expected-key",
+                resolvers=(resolver,),
+                now=NOW,
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(
+            set(sidecar),
+            {"signature_version", "payload_path", "payload_sha256", "algorithm", "key_hint", "signature"},
+        )
+        self.assertEqual(sidecar["signature_version"], "1.0")
+        self.assertEqual(sidecar["key_hint"], "expected-key")
+
+    def test_explicit_key_hint_remains_advisory_sidecar_metadata(self):
+        with tempfile.TemporaryDirectory() as td:
+            bundle = Path(td) / "bundle.yaml"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            sidecar = sign_bundle_with_policy(
+                bundle,
+                _policy(),
+                "expected-key",
+                key_hint="different-advisory-label",
+                resolvers=(EnvironmentKeyResolver({"SYNTHETIC_KEY": "synthetic-policy-key"}),),
+                now=NOW,
+            )
+
+        self.assertEqual(sidecar["key_hint"], "different-advisory-label")
+
+    def test_verify_only_revoked_unknown_and_future_keys_fail_before_resolution(self):
+        with tempfile.TemporaryDirectory() as td:
+            bundle = Path(td) / "bundle.yaml"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            cases = (
+                (_policy(state="verify_only"), "expected-key", "key_not_allowed_for_signing"),
+                (_policy(state="revoked"), "expected-key", "key_revoked"),
+                (_policy(), "missing-key", "unknown_key_id"),
+                (_policy(not_before="2026-08-01T00:00:00Z"), "expected-key", "key_not_active"),
+            )
+            for policy, key_id, expected_code in cases:
+                with self.subTest(expected_code=expected_code), self.assertRaises(PolicySigningError) as caught:
+                    sign_bundle_with_policy(
+                        bundle,
+                        policy,
+                        key_id,
+                        key_hint="expected-key",
+                        resolvers=(EnvironmentKeyResolver({}),),
+                        now=NOW,
+                    )
+                self.assertEqual(caught.exception.code, expected_code)
+                self.assertEqual(policy_signing_exit_code(caught.exception), 1)
+
+    def test_resolution_failure_is_infrastructure_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            bundle = Path(td) / "bundle.yaml"
+            bundle.write_text("title: Synthetic\n", encoding="utf-8")
+            with self.assertRaises(PolicySigningError) as caught:
+                sign_bundle_with_policy(
+                    bundle,
+                    _policy(),
+                    "expected-key",
+                    resolvers=(EnvironmentKeyResolver({}),),
+                    now=NOW,
+                )
+
+        self.assertEqual(caught.exception.code, "key_resolution_failed")
+        self.assertEqual(caught.exception.cause_code, "key_reference_missing")
+        self.assertEqual(policy_signing_exit_code(caught.exception), 2)
+
+
+class PolicySigningCliTests(unittest.TestCase):
+    def _write_fixture(self, root: Path, *, state: str = "active") -> tuple[Path, Path, Path]:
+        bundle = root / "bundle.yaml"
+        key = root / "synthetic.key"
+        policy = root / "trust-policy.yaml"
+        bundle.write_text("title: Synthetic\n", encoding="utf-8")
+        key.write_bytes(b"synthetic-policy-key")
+        policy.write_text(
+            "policy_version: '1.0'\npolicy_id: synthetic-cli-policy\nkeys:\n"
+            "  - key_id: expected-key\n    algorithm: hmac-sha256\n"
+            f"    key_ref: file:{key.name}\n    state: {state}\n"
+            "    not_before: '2026-01-01T00:00:00Z'\n",
+            encoding="utf-8",
+        )
+        return bundle, key, policy
+
+    def test_cli_signs_with_relative_policy_file_reference(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, _, policy = self._write_fixture(root)
+            output = root / "bundle.yaml.sig.json"
+            code = main(
+                [
+                    "evidence",
+                    "sign",
+                    str(bundle),
+                    "--trust-policy",
+                    str(policy),
+                    "--key-id",
+                    "expected-key",
+                    "-o",
+                    str(output),
+                ]
+            )
+            sidecar = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(code, 0)
+        self.assertEqual(sidecar["key_hint"], "expected-key")
+        self.assertEqual(sidecar["signature_version"], "1.0")
+
+    def test_cli_policy_dry_run_prints_sidecar_without_writing_one(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, _, policy = self._write_fixture(root)
+            with contextlib.redirect_stdout(io.StringIO()) as stdout:
+                code = main(
+                    [
+                        "evidence",
+                        "sign",
+                        str(bundle),
+                        "--trust-policy",
+                        str(policy),
+                        "--key-id",
+                        "expected-key",
+                        "--dry-run",
+                    ]
+                )
+            sidecar = json.loads(stdout.getvalue())
+
+        self.assertEqual(code, 0)
+        self.assertEqual(sidecar["key_hint"], "expected-key")
+
+    def test_cli_disallowed_state_returns_1_without_writing_sidecar(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, _, policy = self._write_fixture(root, state="verify_only")
+            output = root / "bundle.yaml.sig.json"
+            with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                code = main(
+                    [
+                        "evidence",
+                        "sign",
+                        str(bundle),
+                        "--trust-policy",
+                        str(policy),
+                        "--key-id",
+                        "expected-key",
+                        "-o",
+                        str(output),
+                    ]
+                )
+
+        self.assertEqual(code, 1)
+        self.assertIn("key_not_allowed_for_signing", stderr.getvalue())
+        self.assertFalse(output.exists())
+
+    def test_cli_missing_key_reference_returns_2_without_writing_sidecar(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, key, policy = self._write_fixture(root)
+            key.unlink()
+            output = root / "bundle.yaml.sig.json"
+            with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                code = main(
+                    [
+                        "evidence",
+                        "sign",
+                        str(bundle),
+                        "--trust-policy",
+                        str(policy),
+                        "--key-id",
+                        "expected-key",
+                        "-o",
+                        str(output),
+                    ]
+                )
+
+        self.assertEqual(code, 2)
+        self.assertIn("key_resolution_failed", stderr.getvalue())
+        self.assertIn("key_reference_missing", stderr.getvalue())
+        self.assertFalse(output.exists())
+
+    def test_cli_invalid_policy_returns_2_without_writing_sidecar(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, _, policy = self._write_fixture(root)
+            policy.write_text("policy_version: [broken\n", encoding="utf-8")
+            output = root / "bundle.yaml.sig.json"
+            with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                code = main(
+                    [
+                        "evidence",
+                        "sign",
+                        str(bundle),
+                        "--trust-policy",
+                        str(policy),
+                        "--key-id",
+                        "expected-key",
+                        "-o",
+                        str(output),
+                    ]
+                )
+
+        self.assertEqual(code, 2)
+        self.assertIn("policy_parse_error", stderr.getvalue())
+        self.assertFalse(output.exists())
+
+    def test_cli_requires_key_id_only_for_policy_mode(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, key, policy = self._write_fixture(root)
+            commands = (
+                ["evidence", "sign", str(bundle), "--trust-policy", str(policy), "--dry-run"],
+                ["evidence", "sign", str(bundle), "--trust-policy", str(policy), "--key-id", "", "--dry-run"],
+                ["evidence", "sign", str(bundle), "--key", str(key), "--key-id", "expected-key", "--dry-run"],
+            )
+            for command in commands:
+                with self.subTest(command=command), contextlib.redirect_stderr(io.StringIO()) as stderr:
+                    self.assertEqual(main(command), 2)
+                    self.assertIn("error:", stderr.getvalue())
+
+    def test_cli_does_not_overwrite_selected_policy_key(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            bundle, key, policy = self._write_fixture(root)
+            before = key.read_bytes()
+            with contextlib.redirect_stderr(io.StringIO()) as stderr:
+                code = main(
+                    [
+                        "evidence",
+                        "sign",
+                        str(bundle),
+                        "--trust-policy",
+                        str(policy),
+                        "--key-id",
+                        "expected-key",
+                        "-o",
+                        str(key),
+                    ]
+                )
+            self.assertEqual(code, 2)
+            self.assertIn("must not overwrite", stderr.getvalue())
+            self.assertEqual(key.read_bytes(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add policy-aware signing with caller-selected `--trust-policy` and `--key-id`
- permit signing only for `active` keys after `not_before`; reject `verify_only`, revoked, unknown, and future keys before resolution
- resolve only local parser-approved key references and preserve the existing version 1 sidecar shape
- keep `key_hint` advisory and preserve the legacy `--key` signing path
- document the CLI, compatibility boundary, and roadmap state

## Why

Issue #65 is the final separately reviewed signer-trust slice after policy-aware verification landed in #71. It adds active-only signing without expanding into public identity, signing-time proof, remote key services, or artifact-correctness claims.

## Validation

- `uv run pytest -q` — 117 passed, 32 subtests passed
- `uv run --extra schema pytest -q` — 117 passed, 32 subtests passed
- `uv run --extra dev coverage run -m unittest discover -s tests` — 115 tests passed before the final two test-only additions; 89% total coverage
- `uv run ruff check src tests scripts`
- `uv run mypy src`
- `git diff --check`
- `python3 scripts/smoke_examples.py`
- `python3 scripts/release_install_smoke.py .`
- `python3 scripts/release_install_smoke.py '.[schema]'`

Closes #65
